### PR TITLE
Simulator Tests, LUT, and Fixes

### DIFF
--- a/src/lib/STAST.hs
+++ b/src/lib/STAST.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 module STAST where
 import STTypes
 import STMetrics
@@ -85,10 +86,26 @@ data ComposeResult =
 -- get the ops contained inside other ops, for going down ComposeFailure trees
 getChildOp n op = getChildOps op !! n
 getChildOps :: Op -> [Op]
-getChildOps (Add t) = []
-getChildOps (Sub t) = []
-getChildOps (Mul t) = []
-getChildOps (Div t) = []
+getChildOps (Add _) = []
+getChildOps (Sub _) = []
+getChildOps (Mul _) = []
+getChildOps (Div _) = []
+getChildOps (Max _) = []
+getChildOps (Min _) = []
+getChildOps (Ashr _ _) = []
+getChildOps (Shl  _ _) = []
+getChildOps (Abs _) = []
+getChildOps (Not _) = []
+getChildOps (And _) = []
+getChildOps (Or _) = []
+getChildOps (XOr _) = []
+getChildOps (Eq) = []
+getChildOps (Neq) = []
+getChildOps (Lt) = []
+getChildOps (Leq) = []
+getChildOps (Gt) = []
+getChildOps (Geq) = []
+getChildOps (LUT _) = []
 getChildOps (MemRead _) = []
 getChildOps (MemWrite _) = []
 getChildOps (LineBuffer _ _ _ _) = []
@@ -96,6 +113,7 @@ getChildOps (Constant_Int _) = []
 getChildOps (Constant_Bit _) = []
 getChildOps (SequenceArrayRepack _ _ _) = []
 getChildOps (ArrayReshape _ _) = []
+getChildOps (DuplicateOutputs _ op) = [op]
 getChildOps (MapOp _ op) = [op]
 getChildOps (ReduceOp _ _ op) = [op]
 getChildOps (Underutil _ op) = [op]

--- a/src/lib/STAST.hs
+++ b/src/lib/STAST.hs
@@ -24,6 +24,8 @@ data Op =
   | Leq
   | Gt
   | Geq
+  -- Ints are the entries in the table. First entry is index 0
+  | LUT [Int]
   | MemRead TokenType
   | MemWrite TokenType
   -- first arg is pixels per clock in each dimension. First value in list is outer 

--- a/src/lib/STAnalysis.hs
+++ b/src/lib/STAnalysis.hs
@@ -420,6 +420,7 @@ inPorts Lt = twoInSimplePorts T_Int
 inPorts Leq = twoInSimplePorts T_Int
 inPorts Gt = twoInSimplePorts T_Int
 inPorts Geq = twoInSimplePorts T_Int
+inPorts (LUT _) = oneInSimplePort T_Int
 
 inPorts (MemRead _) = []
 inPorts (MemWrite t) = [T_Port "I" baseWithNoWarmupSequenceLen t 1]
@@ -493,6 +494,7 @@ outPorts Lt = oneOutSimplePort T_Bit
 outPorts Leq = oneOutSimplePort T_Bit
 outPorts Gt = oneOutSimplePort T_Bit
 outPorts Geq = oneOutSimplePort T_Bit
+outPorts (LUT _) = oneOutSimplePort T_Int
 
 outPorts (MemRead t) = oneOutSimplePort t
 outPorts (MemWrite _) = []

--- a/src/lib/STAnalysis.hs
+++ b/src/lib/STAnalysis.hs
@@ -29,7 +29,7 @@ space Lt = space (Add T_Int)
 space Leq = space (Add T_Int)
 space Gt = space (Add T_Int)
 space Geq = space (Add T_Int)
-
+space (LUT table) = OWA (len T_Int) (length table * len T_Int)
 
 space (MemRead t) = OWA (len t) (len t)
 space (MemWrite t) = OWA (len t) (len t)
@@ -114,6 +114,7 @@ clocksPerSequence Lt = baseWithNoWarmupSequenceLen
 clocksPerSequence Leq = baseWithNoWarmupSequenceLen
 clocksPerSequence Gt = baseWithNoWarmupSequenceLen
 clocksPerSequence Geq = baseWithNoWarmupSequenceLen
+clocksPerSequence (LUT _) = baseWithNoWarmupSequenceLen
 
 -- to what degree can we pipeline MemRead and MemWrite
 clocksPerSequence (MemRead _) = baseWithNoWarmupSequenceLen
@@ -184,6 +185,7 @@ initialLatency Lt = 1
 initialLatency Leq = 1
 initialLatency Gt = 1
 initialLatency Geq = 1
+initialLatency (LUT _) = 1
 
 initialLatency (MemRead _) = 1
 initialLatency (MemWrite _) = 1
@@ -273,6 +275,7 @@ maxCombPath Lt = 1
 maxCombPath Leq = 1
 maxCombPath Gt = 1
 maxCombPath Geq = 1
+maxCombPath (LUT _) = 1
 
 maxCombPath (MemRead _) = 1
 maxCombPath (MemWrite _) = 1
@@ -328,6 +331,7 @@ util Lt = 1
 util Leq = 1
 util Gt = 1
 util Geq = 1
+util (LUT _) = 1
 
 util (MemRead _) = 1
 util (MemWrite _) = 1
@@ -561,6 +565,7 @@ isComb Lt = True
 isComb Leq = True
 isComb Gt = True
 isComb Geq = True
+isComb (LUT _) = True
 
 -- this is meaningless for this units that don't have both and input and output
 isComb (MemRead _) = True

--- a/src/lib/STSimulate.hs
+++ b/src/lib/STSimulate.hs
@@ -126,7 +126,7 @@ simhl Lt inSeqs state = (simhlCombinational simhlLt inSeqs, state)
 simhl Leq inSeqs state = (simhlCombinational simhlLeq inSeqs, state)
 simhl Gt inSeqs state = (simhlCombinational simhlGt inSeqs, state)
 simhl Geq inSeqs state = (simhlCombinational simhlGeq inSeqs, state)
-simhl (LUT i) inSeqs state = (simhlCombinational (simhlLUT i) inSeqs, state)
+simhl (LUT table) inSeqs state = (simhlCombinational (simhlLUT table) inSeqs, state)
 
 -- HACK the constant generators don't really know how long their
 -- output sequences should be, so they look at the simhlConstSeqLen

--- a/src/lib/STSimulate.hs
+++ b/src/lib/STSimulate.hs
@@ -12,22 +12,25 @@ import Data.List
 -- Useful for verifying that the logic of the circuit is correct, but
 -- doesn't simulate the actual hardware implementation.
 --
--- Second Argument: Port Inputs: list of lists of ValueType. Each list entry of the outer
--- list corresponds (in order) to one input port. These inner list
--- entries are a sequence of input values for said port, with each
--- value corresponding to one input on a "meaningful" clock
--- cycle. (i.e.  skip garbage inputs -- for devices that aren't
--- underutilized and have no warmup, this corresponds to a list of
--- inputs on each clock cycle).
+-- First Argument - Simulated Operator.
+--
+-- Second Argument - Port Inputs: list of lists of ValueType. Each list
+-- entry of the outer list corresponds (in order) to one input
+-- port. These inner list entries are a sequence of input values for
+-- said port, with each value corresponding to one input on a
+-- "meaningful" clock cycle. (i.e.  skip garbage inputs -- for devices
+-- that aren't underutilized and have no warmup, this corresponds to a
+-- list of inputs on each clock cycle).
 --
 -- NOTE: Be careful if some ports have a longer/shorter sequence of
 -- inputs than expected.
 --
--- Third Argument: Memory input: list of lists of ValueType. The inner lists are
--- "tapes" of input corresponding to one MemRead, which outputs the
--- tape's values sequentially. Index i of the outer list corresponds
--- to the input for the ith MemRead, which are numbered in the order
--- they would be visited by a depth-first search (DFS) of the AST.
+-- Third Argument - Memory input: list of lists of ValueType. The
+-- inner lists are "tapes" of input corresponding to one MemRead,
+-- which outputs the tape's values sequentially. Index i of the outer
+-- list corresponds to the input for the ith MemRead, which are
+-- numbered in the order they would be visited by a depth-first search
+-- (DFS) of the AST.
 --
 -- NOTE: At time of writing, DFS order may not be well-defined by some
 -- ops like ReduceOp.
@@ -42,6 +45,8 @@ import Data.List
 simulateHighLevel ::
      Op -> [[ValueType]] -> [[ValueType]] -> ([[ValueType]], [[ValueType]])
 -- Check that the types match, then delegate to simhl implementation.
+simulateHighLevel op _ _ | hasChildWithError op || isFailure op =
+  error $ "Op has error: " ++ show op
 simulateHighLevel op portInputs memoryInputs =
     if simhlCheckInputs 0 (inPorts op) portInputs
     then do { let maxSeqLen =

--- a/src/lib/STSimulate.hs
+++ b/src/lib/STSimulate.hs
@@ -126,7 +126,7 @@ simhl Lt inSeqs state = (simhlCombinational simhlLt inSeqs, state)
 simhl Leq inSeqs state = (simhlCombinational simhlLeq inSeqs, state)
 simhl Gt inSeqs state = (simhlCombinational simhlGt inSeqs, state)
 simhl Geq inSeqs state = (simhlCombinational simhlGeq inSeqs, state)
---simhl LUT inSeqs state = (simhlCombinational simhlLut inSeqs, state)
+simhl (LUT i) inSeqs state = (simhlCombinational (simhlLUT i) inSeqs, state)
 
 -- HACK the constant generators don't really know how long their
 -- output sequences should be, so they look at the simhlConstSeqLen
@@ -304,6 +304,15 @@ simhlGt = simhlIntCmpOp (>)
 
 simhlGeq :: [ValueType] -> [ValueType]
 simhlGeq = simhlIntCmpOp (>=)
+
+-- this will be used above by passing in the lookup table as first argument
+-- list of ints. This will partially evaulated then handed to 
+-- simhlCombinational
+simhlLUT :: [Int] -> [ValueType] -> [ValueType]
+simhlLUT table [V_Int i] | i < length table = [V_Int $ table !! i]
+simhlLUT table [V_Int i] = [V_Int 0]
+simhlLUT _ [V_Unit] = [V_Unit]
+simhlLUT _ _ = error "Aetherling internal error: non-unit garbage LUT input"
 
 -- Reshape sequence of arrays through space and time.
 simhlRepack :: (Int,Int) -> (Int,Int) -> TokenType -> [[ValueType]]

--- a/src/lib/STSimulate.hs
+++ b/src/lib/STSimulate.hs
@@ -12,7 +12,7 @@ import Data.List
 -- Useful for verifying that the logic of the circuit is correct, but
 -- doesn't simulate the actual hardware implementation.
 --
--- Input: list of lists of ValueType. Each list entry of the outer
+-- Second Argument: Port Inputs: list of lists of ValueType. Each list entry of the outer
 -- list corresponds (in order) to one input port. These inner list
 -- entries are a sequence of input values for said port, with each
 -- value corresponding to one input on a "meaningful" clock
@@ -23,7 +23,7 @@ import Data.List
 -- NOTE: Be careful if some ports have a longer/shorter sequence of
 -- inputs than expected.
 --
--- Memory input: list of lists of ValueType. The inner lists are
+-- Third Argument: Memory input: list of lists of ValueType. The inner lists are
 -- "tapes" of input corresponding to one MemRead, which outputs the
 -- tape's values sequentially. Index i of the outer list corresponds
 -- to the input for the ith MemRead, which are numbered in the order
@@ -39,8 +39,8 @@ import Data.List
 --
 -- TODO: More convenient error messages?
 -- TODO: Warnings when input sequence lengths don't match.
-simulateHighLevel :: Op -> [[ValueType]] -> [[ValueType]]
-                  -> ( [[ValueType]], [[ValueType]] )
+simulateHighLevel ::
+     Op -> [[ValueType]] -> [[ValueType]] -> ([[ValueType]], [[ValueType]])
 -- Check that the types match, then delegate to simhl implementation.
 simulateHighLevel op portInputs memoryInputs =
     if simhlCheckInputs 0 (inPorts op) portInputs
@@ -126,6 +126,7 @@ simhl Lt inSeqs state = (simhlCombinational simhlLt inSeqs, state)
 simhl Leq inSeqs state = (simhlCombinational simhlLeq inSeqs, state)
 simhl Gt inSeqs state = (simhlCombinational simhlGt inSeqs, state)
 simhl Geq inSeqs state = (simhlCombinational simhlGeq inSeqs, state)
+--simhl LUT inSeqs state = (simhlCombinational simhlLut inSeqs, state)
 
 -- HACK the constant generators don't really know how long their
 -- output sequences should be, so they look at the simhlConstSeqLen
@@ -203,19 +204,18 @@ simhl (ComposeFailure foo bar) _ _ =
 -- with entries corresponding to input ports' inputs in 1 cycle and
 -- produces list of output ports' outputs.
 simhlCombinational :: ([ValueType]->[ValueType]) -> [[ValueType]] -> [[ValueType]]
+simhlCombinational impl inSeqs | any null inSeqs = []
 simhlCombinational impl inSeqs =
-    if any null inSeqs -- inefficient??? Note that we silently ignore
-    then []            -- sequence length mismatches for now.
-    else do { let inputsNow = map head inSeqs
-            ; let inputsL8r = map tail inSeqs
-            ; let outputsNow = impl inputsNow
-            ; let outputsL8r = simhlCombinational impl inputsL8r
-            ; if null outputsL8r
-              then [[outputNow] | outputNow <- outputsNow] -- 1-seq output case
-              else                                         -- N-seq output case
-              [outputNow:outputL8r
-              |(outputNow, outputL8r) <- zip outputsNow outputsL8r]
-            }
+  let
+    inputsNow = map head inSeqs
+    inputsLater = map tail inSeqs
+    outputsNow = impl inputsNow
+    outputsLater = simhlCombinational impl inputsLater
+  in if null outputsLater
+  then [[outputNow] | outputNow <- outputsNow] -- 1-seq output case
+  else                                         -- N-seq output case
+    [outputNow:outputLater
+    |(outputNow, outputLater) <- zip outputsNow outputsLater]
 
 -- Given implementations for Ints and Bools, create a [ValueType] -> [ValueType]
 -- function suitable for simhlCombinational.

--- a/test/TestExamples.hs
+++ b/test/TestExamples.hs
@@ -2,12 +2,13 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import STAST
 import Examples
+import TestSimulator
 
 main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Example Tests" [unitTests]
+tests = testGroup "Example Tests" [unitTests, simulatorTests]
 
 isSuccess :: Op -> Bool
 isSuccess (ComposeFailure _ _) = False

--- a/test/TestSimulator.hs
+++ b/test/TestSimulator.hs
@@ -1,0 +1,226 @@
+{-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
+module TestSimulator where
+import STAST
+import STAnalysis
+import STComposeOps
+import STSimulate
+import STTypes
+import Data.Bits
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- HACK We don't have a "no-op" operator yet, but we do have array
+-- reshape so we can simulate no-op with an array reshape that doesn't
+-- actually reshape anything.
+noOp :: [TokenType] -> Op
+noOp tokens = ArrayReshape tokens tokens
+
+-- Tests for the high level simulator.  We have some operators, and
+-- reimplementations of those operators in pure Haskell. Generate a
+-- bunch of random data, and see if the simulated op gives the same
+-- result as the Haskell implementation with the same inputs.
+--
+-- We're not really testing abuses of the simulator here,
+-- e.g. mismatched input sequence lengths and the like. Maybe make the
+-- simulator more robust in the future.
+
+-- Simple xorshift generator. Copied from Wikipedia.  Give a rand
+-- object in and get a random int and next state of rand out.
+-- Implement it myself since it makes results easy to replicate and we
+-- don't need quality random numbers anyway.
+data SimhlRand = SimhlRand { simhlRandState :: Int }
+
+simhlRandInt :: SimhlRand -> (SimhlRand, Int)
+simhlRandInt (SimhlRand state) =
+  do { let x1 = (shiftL state 13) `xor` state
+     ; let x2 = (shiftR x1 17) `xor` x1
+     ; let x3 = (shiftL x2 5)  `xor` x2
+     ; let x32bits = x3 .&. 0xFFFFFFFF
+     ; (SimhlRand x32bits, x32bits)
+  }
+
+simhlRandBool :: SimhlRand -> (SimhlRand, Bool)
+simhlRandBool inRand =
+  do { let (outRand, x) = simhlRandInt inRand
+     ; (outRand, x .&. 1 == 1)
+  }
+
+-- Get a sequence of seqLen random ValueTypes, suitable for simulating
+-- an op with an input port with given TokenType. Returns the random
+-- generator with advanced state and the random sequence generated.
+simhlRandValues :: SimhlRand -> Int -> TokenType -> (SimhlRand, [ValueType])
+simhlRandValues inRand 0 _ = (inRand, [])
+simhlRandValues inRand seqLen T_Unit = (inRand, replicate seqLen V_Unit)
+simhlRandValues inRand seqLen T_Int =
+  do { let (nextRand, theInt) = simhlRandInt inRand
+     ; let (outRand, moreValues) = simhlRandValues nextRand (seqLen-1) T_Int
+     ; (outRand, (V_Int theInt):moreValues)
+  }
+simhlRandValues inRand seqLen T_Bit =
+  do { let (nextRand, theBool) = simhlRandBool inRand
+     ; let (outRand, moreValues) = simhlRandValues nextRand (seqLen-1) T_Int
+     ; (outRand, (V_Bit theBool):moreValues)
+  }
+simhlRandValues inRand seqLen (T_Array n t) =
+  do { let (nextRand, array) = simhlRandValues inRand n t
+     ; let (outRand, moreArrays) = simhlRandValues nextRand (seqLen-1) (T_Array n t)
+     ; (outRand, (V_Array array):moreArrays)
+  }
+
+-- Look at the op's input ports and generate suitable random input.
+simhlOpRandInputs :: SimhlRand -> Op -> Int -> (SimhlRand, [[ValueType]])
+simhlOpRandInputs inRand op seqLen =
+  do { let inTypes = map pTType (inPorts op)
+     ; let foldLambda = \(prevRand, results) t ->
+             do { let (nextRand, values) = simhlRandValues prevRand seqLen t
+                ; (nextRand, results ++ [values])
+             }
+     ; foldl foldLambda (inRand, []) inTypes
+  }
+
+-- Similar for a list of (sequence length :: Int, type :: TokenType)
+-- Used for generating memory inputs, see SimhlTestCase.
+simhlMemRandInputs :: SimhlRand -> [(Int, TokenType)]
+                   -> (SimhlRand, [[ValueType]])
+simhlMemRandInputs inRand [] = (inRand, [])
+simhlMemRandInputs inRand (tuple:tuples) =
+  do { let (nextRand, value) = simhlRandValues inRand (fst tuple) (snd tuple)
+     ; let (outRand, values) = simhlMemRandInputs nextRand tuples
+     ; (outRand, value:values)
+  }
+  
+
+-- Test case data for the simulator tests.  Includes a description for
+-- the op being tested, the op, a manually-implemented function that
+-- should behave just as the tested op's simulation does, and a test
+-- sequence length and list of memory inputs (sequence len and type)
+-- expected.
+data SimhlTestCase = SimhlTestCase {
+  simhlTestDescription :: String,
+  simhlTestOp :: Op,
+  simhlTestImpl :: [[ValueType]] -> [[ValueType]]
+                -> ( [[ValueType]], [[ValueType]] ),
+  simhlInSeqLen :: Int,
+  simhlMemTypes :: [(Int, TokenType)]
+}
+
+simhlMakeTestCases :: SimhlRand -> [SimhlTestCase] -> [TestTree]
+simhlMakeTestCases _ [] = []
+simhlMakeTestCases inRand (thisCase:cases) =
+  do { let op = simhlTestOp thisCase
+     ; let (memRand, inSeqs) = simhlOpRandInputs inRand op
+                                                 (simhlInSeqLen thisCase)
+     ; let (nextRand, inMem) = simhlMemRandInputs memRand
+                                                  (simhlMemTypes thisCase)
+     ; let tree = testCase (simhlTestDescription thisCase) $
+                  (simulateHighLevel op inSeqs inMem)
+              @?= ((simhlTestImpl thisCase) inSeqs inMem)
+     ; let trees = simhlMakeTestCases nextRand cases
+     ; tree:trees
+  }
+
+-- Take two vec4s, subtract them, and double the result.
+-- Note that the implementation function has a bunch of ugly list
+-- comprehesions for dealing with the full sequence of input values.
+-- Later, I'll re-use simhlCombinational to automatically deal with it.
+-- If this test case passes, then simhlCombinational is trustworthy.
+vec4SubTimes8Op = MapOp 4 ((Sub T_Int) |>>=| (Shl 3 T_Int))
+vec4SubTimes8Impl :: [[ValueType]] -> [[ValueType]]
+                  -> ( [[ValueType]], [[ValueType]] )
+vec4SubTimes8Impl inSeqs _ =
+  do { let [leftSeq, rightSeq] = inSeqs
+     ; ([[V_Array
+          [V_Int (8*(a-b)) | (V_Int a, V_Int b) <- zip leftArray rightArray]
+        | (V_Array leftArray, V_Array rightArray) <- zip leftSeq rightSeq
+        ]],
+        []
+       )
+  }
+simhlCase0 = SimhlTestCase
+  "Subtract 4-vec, then multiply by 8. (Tests Sub, Shl, MapOp)"
+  vec4SubTimes8Op
+  vec4SubTimes8Impl
+  237
+  []
+
+-- Helper function for creating reference implementations for
+-- combinational devices. I just copied simhlCombinational but
+-- modified it to deal with the extra memory argument. As explained,
+-- the last test case should have ensured simhlCombinational works
+-- correctly.
+simhlCombinational2 :: ([ValueType]->[ValueType]) -> [[ValueType]] -> [[ValueType]]
+                    -> ( [[ValueType]], [[ValueType]] )
+simhlCombinational2 impl inSeqs _ =
+  if any null inSeqs
+  then ([], [])
+  else do { let inputsNow = map head inSeqs
+          ; let inputsL8r = map tail inSeqs
+          ; let outputsNow = impl inputsNow
+          ; let outputsL8r = simhlCombinational impl inputsL8r
+          ; let allOutputs =
+                 if null outputsL8r
+                 then [[outputNow] | outputNow <- outputsNow] -- 1-seq output case
+                 else                                         -- N-seq output case
+                 [outputNow:outputL8r
+                 |(outputNow, outputL8r) <- zip outputsNow outputsL8r]
+          ; (allOutputs, [])
+       }
+
+-- ((a xor b) / (c|100)) >> 5
+simhlCase1Op =
+  (XOr T_Int |&| noOp [T_Int] |&| Constant_Int [100]) |>>=|
+  (ArrayReshape [T_Int, T_Int, T_Array 1 T_Int] [T_Int, T_Int, T_Int]) |>>=|
+  (noOp [T_Int] |&| Or T_Int) |>>=|
+  (Div T_Int)
+simhlCase1Combinational :: [ValueType] -> [ValueType]
+simhlCase1Combinational [V_Int a, V_Int b, V_Int c] =
+  [V_Int ((a `xor` b) `div` (c .|. 100))]
+simhlCase1 = SimhlTestCase
+  "((a xor b) / (c | 100)). (Tests XOr, Or, Div)"
+  simhlCase1Op
+  (simhlCombinational2 simhlCase1Combinational)
+  133
+  []
+
+-- Check if both entries of input array have the same parity
+simhlParityMatchOp =
+  (noOp [T_Int] |&| Constant_Int [1, 1] |&| noOp [T_Int]) |>>=|
+  (ArrayReshape [T_Int, T_Array 2 T_Int, T_Int] [T_Int, T_Int, T_Int, T_Int]) |>>=|
+  (And T_Int |&| And T_Int) |>>=|
+  Eq
+simhlParityMatchCombinational :: [ValueType] -> [ValueType]
+simhlParityMatchCombinational [V_Int a, V_Int b] =
+  [V_Bit (all odd [a,b] || all even [a,b])]
+simhlCase2 = SimhlTestCase
+  "Check matching parity (Tests And, Eq, ArrayReshape)"
+  simhlParityMatchOp
+  (simhlCombinational2 simhlParityMatchCombinational)
+  144
+  []
+
+-- Check that every entry of a 5-array is even.
+simhlAllEvenOp =
+  (noOp [T_Array 5 T_Int] |&| Constant_Int [1,1,1,1,1]) |>>=|
+  (And (T_Array 5 T_Int)   |&| Constant_Int [1]) |>>=|
+  (ReduceOp 5 5 (Or T_Int) |&| ArrayReshape [T_Array 1 T_Int] [T_Int]) |>>=|
+  (Neq)
+  
+simhlAllEvenCombinational :: [ValueType] -> [ValueType]
+simhlAllEvenCombinational [V_Array [V_Int a, V_Int b, V_Int c, V_Int d, V_Int e]] =
+  [V_Bit $ all even [a,b,c,d,e]]
+simhlCase3 = SimhlTestCase
+  "Check that 5-array has only even numbers (Tests Constant_Int, ReduceOp, Or, Neq)"
+  simhlAllEvenOp
+  (simhlCombinational2 simhlAllEvenCombinational)
+  101
+  []
+
+simhlSeed = 1337
+
+simulatorTests = testGroup ("High level simulator tests, seed " ++ show simhlSeed)
+  $ simhlMakeTestCases (SimhlRand simhlSeed) [
+      simhlCase0,
+      simhlCase1,
+      simhlCase2,
+      simhlCase3
+    ]

--- a/test/TestSimulator.hs
+++ b/test/TestSimulator.hs
@@ -9,12 +9,6 @@ import Data.Bits
 import Test.Tasty
 import Test.Tasty.HUnit
 
--- HACK We don't have a "no-op" operator yet, but we do have array
--- reshape so we can simulate no-op with an array reshape that doesn't
--- actually reshape anything.
-noOp :: [TokenType] -> Op
-noOp tokens = ArrayReshape tokens tokens
-
 -- Tests for the high level simulator.  We have some operators, and
 -- reimplementations of those operators in pure Haskell. Generate a
 -- bunch of random data, and see if the simulated op gives the same
@@ -22,12 +16,31 @@ noOp tokens = ArrayReshape tokens tokens
 --
 -- We're not really testing abuses of the simulator here,
 -- e.g. mismatched input sequence lengths and the like. Maybe make the
--- simulator more robust in the future.
+-- simulator more robust in the future.  I'm also not testing "abs"
+-- operator. I'm a little confused about what it's really supposed to
+-- do, since ints were all unsigned last I heard.
 
--- Simple xorshift generator. Copied from Wikipedia.  Give a rand
--- object in and get a random int and next state of rand out.
--- Implement it myself since it makes results easy to replicate and we
--- don't need quality random numbers anyway.
+
+-- HACK We don't have a "no-op" operator yet, but we do have array
+-- reshape so we can simulate no-op with an array reshape that doesn't
+-- actually reshape anything.
+simhlNoOp :: [TokenType] -> Op
+simhlNoOp tokens = ArrayReshape tokens tokens
+
+-- Also some shorthand to create an op that boxes to/unboxes from 1-arrays.
+simhlBox :: TokenType -> Op
+simhlBox t = ArrayReshape [t] [T_Array 1 t]
+
+simhlUnbox :: TokenType -> Op
+simhlUnbox t = ArrayReshape [T_Array 1 t] [t]
+
+-- Simple xorshift generator; 32 bits state, 8 bit outputs. Copied
+-- from Wikipedia.  Give a rand object in and get a random int and
+-- next state of rand out.  Implement it myself since it makes results
+-- easy to replicate and we don't need quality random numbers anyway.
+-- TODO: Consider replacing with standard library RNG, if we know that
+-- it will always give the same output for a given seed on ALL
+-- machines.
 data SimhlRand = SimhlRand { simhlRandState :: Int }
 
 simhlRandInt :: SimhlRand -> (SimhlRand, Int)
@@ -148,7 +161,8 @@ simhlCase0 = SimhlTestCase
 -- modified it to deal with the extra memory argument. As explained,
 -- the last test case should have ensured simhlCombinational works
 -- correctly.
-simhlCombinationalIgnoreMem :: ([ValueType]->[ValueType]) -> [[ValueType]] -> [[ValueType]]
+simhlCombinationalIgnoreMem :: ([ValueType]->[ValueType])
+                    -> [[ValueType]] -> [[ValueType]]
                     -> ( [[ValueType]], [[ValueType]] )
 simhlCombinationalIgnoreMem impl inSeqs _ =
   if any null inSeqs
@@ -168,13 +182,14 @@ simhlCombinationalIgnoreMem impl inSeqs _ =
 
 -- ((a xor b) / (c|100)) >> 5
 simhlCase1Op =
-  (XOr T_Int |&| noOp [T_Int] |&| Constant_Int [100]) |>>=|
+  (XOr T_Int |&| simhlNoOp [T_Int] |&| Constant_Int [100]) |>>=|
   (ArrayReshape [T_Int, T_Int, T_Array 1 T_Int] [T_Int, T_Int, T_Int]) |>>=|
-  (noOp [T_Int] |&| Or T_Int) |>>=|
+  (simhlNoOp [T_Int] |&| Or T_Int) |>>=|
   (Div T_Int)
 simhlCase1Combinational :: [ValueType] -> [ValueType]
 simhlCase1Combinational [V_Int a, V_Int b, V_Int c] =
   [V_Int ((a `xor` b) `div` (c .|. 100))]
+simhlCase1Combinational _ = error "Aetherling test internal error: case 1"
 simhlCase1 = SimhlTestCase
   "((a xor b) / (c | 100)). (Tests XOr, Or, Div)"
   simhlCase1Op
@@ -184,13 +199,14 @@ simhlCase1 = SimhlTestCase
 
 -- Check if both entries of input array have the same parity
 simhlParityMatchOp =
-  (noOp [T_Int] |&| Constant_Int [1, 1] |&| noOp [T_Int]) |>>=|
+  (simhlNoOp [T_Int] |&| Constant_Int [1, 1] |&| simhlNoOp [T_Int]) |>>=|
   (ArrayReshape [T_Int, T_Array 2 T_Int, T_Int] [T_Int, T_Int, T_Int, T_Int]) |>>=|
   (And T_Int |&| And T_Int) |>>=|
   Eq
 simhlParityMatchCombinational :: [ValueType] -> [ValueType]
 simhlParityMatchCombinational [V_Int a, V_Int b] =
   [V_Bit (all odd [a,b] || all even [a,b])]
+simhlParityMatchCombinational _ = error "Aetherling test internal error: case 2"
 simhlCase2 = SimhlTestCase
   "Check matching parity (Tests And, Eq, ArrayReshape)"
   simhlParityMatchOp
@@ -199,15 +215,17 @@ simhlCase2 = SimhlTestCase
   []
 
 -- Check that every entry of a 5-array is even.
+-- This tests the combinational case of ReduceOp (par = numComb).
 simhlAllEvenOp =
-  (noOp [T_Array 5 T_Int] |&| Constant_Int [1,1,1,1,1]) |>>=|
+  (simhlNoOp [T_Array 5 T_Int] |&| Constant_Int [1,1,1,1,1]) |>>=|
   (And (T_Array 5 T_Int)   |&| Constant_Int [1]) |>>=|
-  (ReduceOp 5 5 (Or T_Int) |&| ArrayReshape [T_Array 1 T_Int] [T_Int]) |>>=|
+  (ReduceOp 5 5 (Or T_Int) |&| simhlUnbox T_Int) |>>=|
   (Neq)
   
 simhlAllEvenCombinational :: [ValueType] -> [ValueType]
 simhlAllEvenCombinational [V_Array [V_Int a, V_Int b, V_Int c, V_Int d, V_Int e]] =
   [V_Bit $ all even [a,b,c,d,e]]
+simhlAllEvenCombinational _ = error "Aetherling test internal error: case 3"
 simhlCase3 = SimhlTestCase
   "Check that 5-array has only even numbers (Tests Constant_Int, ReduceOp, Or, Neq)"
   simhlAllEvenOp
@@ -215,6 +233,7 @@ simhlCase3 = SimhlTestCase
   101
   []
 
+-- It's a LUT.
 lutTable = [0, 2, 4, 6, 1]
 simhlLUTTestOp = LUT lutTable
 simhlLUTTestCombinational :: [ValueType] -> [ValueType]
@@ -223,7 +242,7 @@ simhlLUTTestCombinational :: [ValueType] -> [ValueType]
 simhlLUTTestCombinational [V_Int i] | i < length lutTable = [V_Int $ lutTable !! i]
 simhlLUTTestCombinational [V_Int i] = [V_Int 0]
 simhlLUTTestCombinational [V_Unit] = [V_Unit]
-simhlLUTTestCombinational _ = [V_Unit]
+simhlLUTTestCombinational _ = error "Aetherling test internal error: case 4"
 simhlCase4 = SimhlTestCase
   "Check that LUT actually does lookup"
   simhlLUTTestOp
@@ -231,6 +250,107 @@ simhlCase4 = SimhlTestCase
   100
   []
 
+-- Max of 15 integers, multiplied by 7.  Takes 15 inputs at once, but
+-- uses a reduce with 3 inputs (so underutilization is happenening).
+-- NOTE: Since max is commutative/associative, we're not really testing
+-- SequenceArrayRepack here.
+simhlMul7Max15SpaceOp =
+  (Underutil 5 (ArrayReshape (replicate 15 T_Int) [T_Array 15 T_Int])) |>>=|
+  (SequenceArrayRepack (1, 15) (5, 3) T_Int |&| Underutil 5 (Constant_Int [7]))
+  |>>=|
+  (ReduceOp 3 15 (Max T_Int) |&| Underutil 5 (simhlUnbox T_Int))
+  |>>=|
+  Underutil 5 (Mul T_Int)
+simhlMul7Max15Combinational :: [ValueType] -> [ValueType]
+simhlMul7Max15Combinational inputs = [V_Int $ maximum [7*n | V_Int n <- inputs]]
+simhlCase5 = SimhlTestCase
+  "Maximum of 15 integers, multiplied by 7, using a reduce that takes only\
+        \3 inputs at a time.\
+        \(Tests ReduceOp, Max, SequenceArrayRepack, Underutil)."
+  simhlMul7Max15SpaceOp
+  (simhlCombinationalIgnoreMem simhlMul7Max15Combinational)
+  199
+  []
+
+-- Same thing, but take 15 inputs sequentially.
+simhlMul7Max15TimeOp =
+  (simhlBox T_Int |&| Underutil 15 (Constant_Int [7])) |>>=|
+  (ReduceOp 1 15 (Max T_Int) |&| Underutil 15 (simhlUnbox T_Int)) |>>=|
+  Underutil 15 (Mul T_Int)
+simhlMul7Max15TimeImpl :: [[ValueType]] -> [[ValueType]]
+                       -> ( [[ValueType]], [[ValueType]] )
+simhlMul7Max15TimeImpl portInputs _ =
+  let
+    doMax :: [ValueType] -> [ValueType]
+    doMax inSeq | length inSeq < 15 = []
+    doMax inSeq = (V_Int (7 * maximum [n | V_Int n <- take 15 inSeq])):
+                  (doMax $ drop 15 inSeq)
+  in
+    ([doMax $ head portInputs], [])
+simhlCase6 = SimhlTestCase
+  "Similar to the other maximum times 7, but input is sequential. \
+        \(Tests ReduceOp, Max)"
+  simhlMul7Max15TimeOp
+  simhlMul7Max15TimeImpl
+  150
+  []
+
+-- A is at least 4 times B.
+simhlAtLeast4TimesOp =
+  (Ashr 2 T_Int |&| simhlNoOp [T_Int]) |>>=| Geq
+simhlAtLeast4TimesCombinational :: [ValueType] -> [ValueType]
+simhlAtLeast4TimesCombinational [V_Int a, V_Int b] = [V_Bit (a >= 4*b)]
+simhlAtLeast4TimesCombinational _ = error "Aetherling test internal error: case 7"
+simhlCase7 = SimhlTestCase
+  "a >= 4b, implemented by right-shifting a. (Tests Ashr, Geq)"
+  simhlAtLeast4TimesOp
+  (simhlCombinationalIgnoreMem simhlAtLeast4TimesCombinational)
+  405
+  []
+
+-- 7-vector "less-than" function. True iff a_i < b_i for all i.
+-- Use de-morgan's law to turn this into a test for or, not.
+-- Also add a register just for fun.
+simhlVec7LessThanOp =
+  MapOp 7 Gt |>>=| ReduceOp 7 7 (Or T_Bit) |>>=| RegDelay 1 (Not T_Bit)
+simhlVec7LessThanCombinational :: [ValueType] -> [ValueType]
+simhlVec7LessThanCombinational [V_Array xs, V_Array ys] =
+  [V_Bit $ all (\(x,y) -> x < y) $ zip [x | V_Int x <- xs] [y | V_Int y <- ys]]
+simhlVec7LessThanCombinational _ = error "Aetherling test internal error: case 8"
+simhlCase8 = SimhlTestCase
+  "7-vector 'less than' function. (Tests MapOp, Gt, ReduceOp, Or, Not)"
+  simhlVec7LessThanOp
+  (simhlCombinationalIgnoreMem simhlVec7LessThanCombinational)
+  125
+  []
+
+-- Read two tapes of input, and output their sums and differences to
+-- memory, and their mins to an output port.
+simhlMemSumDiffMinOp =
+  (RegDelay 1 (DuplicateOutputs 3 (MemRead T_Int |&| MemRead T_Int))) |>>=|
+  (RegDelay 2 (Add T_Int |&| Sub T_Int |&| Min T_Int)) |>>=|
+  (MemWrite T_Int |&| MemWrite T_Int |&| simhlNoOp [T_Int])
+simhlMemSumDiffMinImpl :: [[ValueType]] -> [[ValueType]]
+                       -> ( [[ValueType]], [[ValueType]] )
+simhlMemSumDiffMinImpl _ inTapes | any null inTapes = ([[]], [[],[]])
+simhlMemSumDiffMinImpl _ [xv:xvs, yv:yvs] =
+  let
+    (V_Int x, V_Int y) = (xv, yv)
+    theSum = V_Int $ x+y
+    theDiff = V_Int $ x-y
+    theMin = V_Int $ min x y
+    ([theMins], [theSums, theDiffs]) = simhlMemSumDiffMinImpl [] [xvs, yvs]
+  in
+    ([theMin:theMins], [theSum:theSums, theDiff:theDiffs])
+simhlMemSumDiffMinImpl _ _ = error "Aetherling test internal error: case 9"
+simhlCase9 = SimhlTestCase
+  "Read numbers from two memory inputs, output sums and differences to \
+  \memory, minimums to an output port. (Tests RegDelay, \
+  \DuplicateOutputs, MemRead, MemWrite, Add, Sub, Min)"
+  simhlMemSumDiffMinOp
+  simhlMemSumDiffMinImpl
+  180
+  [(180, T_Int), (180, T_Int)]
 
 simhlSeed = 1337
 
@@ -240,5 +360,10 @@ simulatorTests = testGroup ("High level simulator tests, seed " ++ show simhlSee
       simhlCase1,
       simhlCase2,
       simhlCase3,
-      simhlCase4
+      simhlCase4,
+      simhlCase5,
+      simhlCase6,
+      simhlCase7,
+      simhlCase8,
+      simhlCase9
     ]


### PR DESCRIPTION
Fixes include adding new ops to getChildOps, removing unneeded "do", fixed constant generators in simulator, removing unused simhlTypesMatch field from SimhlState, and improved simulateHighLevel documentation.