### PR TITLE
Refactor ThroughputModifications

### DIFF
--- a/src/Core/Aetherling/Analysis/Latency.hs
+++ b/src/Core/Aetherling/Analysis/Latency.hs
@@ -1,6 +1,8 @@
 {-|
 Module: Aetherling.Analysis.Latency 
-Description: Determines the initial latency for how long it takes for a
+Description: Compute latency of Aetherling ops
+
+Determines the initial latency for how long it takes for a
 pipelined module to receive input, and the max combinational path
 for the highest latency, single cycle part of the circuit.
 -}

--- a/src/Core/Aetherling/Analysis/Metrics.hs
+++ b/src/Core/Aetherling/Analysis/Metrics.hs
@@ -1,7 +1,6 @@
 {-|
 Module: Aetherling.Analysis.Metrics
-Description: This provides helper functions and metrics like space used in the
-analysis of ops
+Description: Types and helper functions for analyzing Aetherling ops
 -}
 module Aetherling.Analysis.Metrics where
 import Aetherling.Operations.Types

--- a/src/Core/Aetherling/Analysis/PortsAndThroughput.hs
+++ b/src/Core/Aetherling/Analysis/PortsAndThroughput.hs
@@ -1,6 +1,8 @@
 {-|
 Module: Aetherling.Analysis.PortsAndThroughput
-Description: Determines the input and output ports of an op, the clocks per 
+Description: Compute interfaces of Aetherling ops
+
+Determines the input and output ports of an op, the clocks per 
 sequence used to process the inputs on those ports, and the resulting throughput
 -}
 module Aetherling.Analysis.PortsAndThroughput where

--- a/src/Core/Aetherling/Analysis/PortsAndThroughput.hs
+++ b/src/Core/Aetherling/Analysis/PortsAndThroughput.hs
@@ -55,12 +55,12 @@ inPorts (DuplicateOutputs _ op) = inPorts op
 
 inPorts (MapOp par op) = renamePorts "I" $ liftPortsTypes par (inPorts op)
 -- take the first port of the op and duplicate it par times, don't duplicate both
--- ports of reducer as reducing numComb things in total, not per port
-inPorts (ReduceOp par numComb op) = renamePorts "I" $ map scaleSeqLen $
+-- ports of reducer as reducing numTokens things in total, not per port
+inPorts (ReduceOp numTokens par op) = renamePorts "I" $ map scaleSeqLen $
   liftPortsTypes par $ portToDuplicate $ inPorts op
   where 
     scaleSeqLen (T_Port name origSLen tType pct) =
-      T_Port name (origSLen * (numComb `ceilDiv` par)) tType pct
+      T_Port name (origSLen * (numTokens `ceilDiv` par)) tType pct
     portToDuplicate ((T_Port name sLen tType pct):_) = [T_Port name sLen tType pct]
     portToDuplicate [] = []
 
@@ -238,16 +238,16 @@ clocksPerSequence (MapOp _ op) = cps op
 -- reduce needs to get a complete sequence. If less than parallel,
 -- need to write to register all but last, if fully parallel or more,
 -- reduce is combinational
-clocksPerSequence (ReduceOp par numComb op) |
-  isComb op = combinationalCPS * (numComb `ceilDiv` par)
+clocksPerSequence (ReduceOp numTokens par op) |
+  isComb op = combinationalCPS * (numTokens `ceilDiv` par)
 -- Why not including tree height? Because can always can pipeline.
 -- Putting inputs in every clock where can accept inputs.
--- Just reset register every numComb/par if not fully parallel.
+-- Just reset register every numTokens/par if not fully parallel.
 -- What does it mean to reduce a linebuffer?
 -- can't. Can't reduce anything with a warmup as this will create
 -- an asymmetry between inputs and outputs leading to horrific tree
 -- structure
-clocksPerSequence (ReduceOp par numComb op) = cps op * (numComb `ceilDiv` par)
+clocksPerSequence (ReduceOp numTokens par op) = cps op * (numTokens `ceilDiv` par)
 
 clocksPerSequence (NoOp _) = combinationalCPS
 clocksPerSequence (Underutil denom op) = denom * cps op

--- a/src/Core/Aetherling/Analysis/Space.hs
+++ b/src/Core/Aetherling/Analysis/Space.hs
@@ -69,16 +69,16 @@ space (MapOp par op) = (space op) |* par
 -- area of reduce is area of reduce tree, with area for register for partial
 -- results and counter for tracking iteration time if input is sequence of more
 -- than what is passed in one clock
-space (ReduceOp par numComb op) | par == numComb = (space op) |* (par - 1)
-space rOp@(ReduceOp par numComb op) =
+space (ReduceOp numTokens par op) | par == numTokens = (space op) |* (par - 1)
+space rOp@(ReduceOp numTokens par op) =
   reduceTreeSpace |+| (space op) |+| (registerSpace $ map pTType $ outPorts op)
-  |+| (counterSpace $ numComb * (denominator opThroughput) `ceilDiv` (numerator opThroughput))
+  |+| (counterSpace $ numTokens * (denominator opThroughput) `ceilDiv` (numerator opThroughput))
   where 
     reduceTreeSpace = space (ReduceOp par par op)
     -- need to be able to count all clocks in steady state, as that is when
     -- will be doing reset every nth
-    -- thus, divide numComb by throuhgput in steady state to get clocks for
-    -- numComb to be absorbed
+    -- thus, divide numTokens by throuhgput in steady state to get clocks for
+    -- numTokens to be absorbed
     -- only need throughput from first port as all ports have same throuhgput
     (PortThroughput _ opThroughput) = portThroughput op $ head $ inPorts op
 

--- a/src/Core/Aetherling/Operations/AST.hs
+++ b/src/Core/Aetherling/Operations/AST.hs
@@ -65,7 +65,7 @@ data Op =
 
   -- HIGHER ORDER OPS
   | MapOp {mapParallelism :: Int, mappedOp :: Op}
-  | ReduceOp {reduceParallelism :: Int, reduceNumCombined :: Int, reducedOp :: Op}
+  | ReduceOp {reduceNumTokens :: Int, reduceParallelism :: Int, reducedOp :: Op}
 
   -- TIMING HELPERS
   | NoOp [TokenType]

--- a/src/Core/Aetherling/Operations/AST.hs
+++ b/src/Core/Aetherling/Operations/AST.hs
@@ -1,26 +1,14 @@
 {-|
 Module: Aetherling.Operations.AST
-Description: Provides the Aetherling Abstract Syntax Tree (AST) and functions
+Description: Aetherling's AST
+
+Provides the Aetherling Abstract Syntax Tree (AST) and functions
 for identifying errors in that tree.
 -}
 module Aetherling.Operations.AST where
 import Aetherling.Operations.Types
 
-{-|
-The Aetherling Operations. These are split into four groups:
-1. Leaf, non-modifiable rate - these are arithmetic, boolean logic,
-and bit operations that don't contain any other ops and don't have
-a parameter for making them run with a larger or smaller throughput.
-2. Leaf, modifiable rate - these are ops like linebuffers,
-and space-time type reshapers that have a parameter for changing their
-throughput and typically are not mapped over to change their throuhgput.
-These ops don't have child ops
-3. Parent, non-modifiable rate - these ops like composeSeq and composePar have
-child ops that can have their throughputs' modified, but the parent
-op doesn't have a parameter that affects throughput
-4. Parent, modifiable rate - map is the canonical example. It has child ops
-and can have its throughput modified by changing parallelism.
--} 
+-- | The operations that can be used to create dataflow DAGs in Aetherling
 data Op =
   -- LEAF OPS
   Add TokenType

--- a/src/Core/Aetherling/Operations/Properties.hs
+++ b/src/Core/Aetherling/Operations/Properties.hs
@@ -1,6 +1,8 @@
 {-|
 Module: Aetherling.Operations.Properties
-Description: Describes properties that are intrinsic to operators that do not
+Description: Properties of Aetherling ops that don't require analysis
+
+Describes properties that are intrinsic to operators that do not
 require any analysis, like if the operator has a combinational path from at
 least one input port to one output port.
 -}

--- a/src/Core/Aetherling/Operations/Properties.hs
+++ b/src/Core/Aetherling/Operations/Properties.hs
@@ -54,3 +54,49 @@ isComb (Delay _ op) = False
 isComb (ComposePar ops) = length (filter isComb ops) > 0
 isComb (ComposeSeq ops) = length (filter isComb ops) > 0
 isComb (Failure _) = True
+
+hasInternalState :: Op -> Bool
+hasInternalState (Add t) = False
+hasInternalState (Sub t) = False
+hasInternalState (Mul t) = False
+hasInternalState (Div t) = False
+hasInternalState (Max t) = False
+hasInternalState (Min t) = False
+hasInternalState (Ashr _ t) = False
+hasInternalState (Shl _ t) = False
+hasInternalState (Abs t) = False
+hasInternalState (Not t) = False
+hasInternalState (And t) = False
+hasInternalState (Or t) = False
+hasInternalState (XOr t) = False
+hasInternalState Eq = False
+hasInternalState Neq = False
+hasInternalState Lt = False
+hasInternalState Leq = False
+hasInternalState Gt = False
+hasInternalState Geq = False
+hasInternalState (LUT _) = False
+
+-- this is meaningless for this units that don't have both and input and output
+hasInternalState (MemRead _) = True
+hasInternalState (MemWrite _) = True
+hasInternalState (LineBuffer _ _ _ _ _) = True
+hasInternalState (Constant_Int _) = False
+hasInternalState (Constant_Bit _) = False
+
+hasInternalState (SequenceArrayRepack _ _ _) = True
+hasInternalState (ArrayReshape _ _) = False
+hasInternalState (DuplicateOutputs _ _) = False
+
+hasInternalState (MapOp _ op) = hasInternalState op
+hasInternalState (ReduceOp par numComb op) | par == numComb = hasInternalState op
+hasInternalState (ReduceOp _ _ op) = True
+
+hasInternalState (NoOp tTypes) = False
+hasInternalState (Underutil denom op) = hasInternalState op
+-- since pipelined, this doesn't affect clocks per stream
+hasInternalState (Delay _ op) = hasInternalState op
+
+hasInternalState (ComposePar ops) = length (filter hasInternalState ops) > 0
+hasInternalState (ComposeSeq ops) = length (filter hasInternalState ops) > 0
+hasInternalState (Failure _) = True

--- a/src/Core/Aetherling/Operations/Properties.hs
+++ b/src/Core/Aetherling/Operations/Properties.hs
@@ -43,7 +43,7 @@ isComb (ArrayReshape _ _) = True
 isComb (DuplicateOutputs _ _) = True
 
 isComb (MapOp _ op) = isComb op
-isComb (ReduceOp par numComb op) | par == numComb = isComb op
+isComb (ReduceOp numTokens par op) | par == numTokens = isComb op
 isComb (ReduceOp _ _ op) = False
 
 isComb (NoOp tTypes) = True 
@@ -89,7 +89,7 @@ hasInternalState (ArrayReshape _ _) = False
 hasInternalState (DuplicateOutputs _ _) = False
 
 hasInternalState (MapOp _ op) = hasInternalState op
-hasInternalState (ReduceOp par numComb op) | par == numComb = hasInternalState op
+hasInternalState (ReduceOp numTokens par op) | par == numTokens = hasInternalState op
 hasInternalState (ReduceOp _ _ op) = True
 
 hasInternalState (NoOp tTypes) = False

--- a/src/Core/Aetherling/Operations/Types.hs
+++ b/src/Core/Aetherling/Operations/Types.hs
@@ -1,6 +1,8 @@
 {-|
 Module: Aetherling.Operations.Types
-Description: Describes Aetherling's type system and the ports of operations
+Description: Type system for interfaces of Aetherling's Ops
+
+Describes Aetherling's type system and the ports of operations
 that accept/emit tokens of those types. PortThroughput is also defined here
 as it is a type used for comparing ports when composing sequences of ops.
 -}

--- a/src/Core/Aetherling/Passes/ThroughputModifications.hs
+++ b/src/Core/Aetherling/Passes/ThroughputModifications.hs
@@ -4,47 +4,50 @@ Description: Passes that tradeoff throughput and area
 
 The Aetherling Operations. These are split into four groups:
 
-1. Leaf, indirectly scalable - these are arithmetic, boolean logic,
-and bit operations that don't contain any other ops and don't have
-a parameter for making them run with a larger or smaller throughput.
-Since these don't have a directly scalable, they are sped up and slowed
-down by wrapping them in a parent, directly scalable op such as map and
-underutil.
+1. Leaf, indirectly scalable - These ops both do not contain any child ops and
+also do not have a parameter for directly scaling their throughput. Examples of
+these ops are arithmetic, boolean logic, and bit operations.
 
-2. Leaf, directly scalable - these are ops like linebuffers,
-and space-time type reshapers that have a parameter for changing their
-throughput and typically are not mapped over to change their throuhgput.
-These ops don't have child ops.
-Since these have a directly scalable, they are sped up and slowed down by
-trying to adjust that rate. In some cases, it may not be possible to adjust
-the rate if the op with the new is invalid given the dimensions of the data
-being operated on. Speed up and slow down may fail in these cases.
+2. Leaf, directly scalable - These ops do not contain any child ops. They do
+have a parameter for directly scaling their throuhgput. Examples of these ops
+are linebuffers and space-time type reshapers. 
 
-3. Parent, indirectly scalable - these ops like composeSeq and composePar have
-child ops that can have their throughputs' modified, but the parent
-op doesn't have a parameter that affects throughput
+3. Parent, indirectly scalable - These ops contain child ops which can be
+directly or indirectly scaled. These ops do not have a parameter for directly
+scaling their throughput. Examples of these ops are composeSeq and composePar.
 
-4. Parent, directly scalable - map is the canonical example. It has child ops
-and can have its throughput modified by changing parallelism.
+4. Parent, directly scalable - These ops both do contain child ops and have a
+parameter for directly scaling their throughput. Examples of these ops are map
+and reduce. There may be restrictions on the types of ops that can be children
+of these ops. These restrictions enable the throughput parameter to be modified
+while ensuring that the input and output remains the same modulo throughput.
 
 The four groups are have their throughputs increased and decreased using
 different approaches:
 
-MAYBE I SHOULD CALL THESE "Leaf, directly scalable"
-1. Leaf, indirectly scalable - these ops are sped up and slowed down by wrapping
-them in a parent, directly scalable op such as map and underutil. 
+1. Leaf, indirectly scalable - Since these aren't directly scalable, they are
+sped up and slowed down by wrapping them in a parent, directly scalable op such
+as map and underutil.
 
-2. Leaf, directly scalable - these ops are sped up and slowed down by trying to
-adjust their rate. In some cases, it may not be possible to adjust the rate if
-the op with the new is invalid given the dimensions of the data being operated
-on. Speed up and slow down may fail in these cases.
+2. Leaf, directly scalable - Since these are directly scalable, they are sped up
+and slowed down by trying to adjust their throughput parameters. In some cases,
+it may not be possible to adjust the parameter. This will happen if the op with
+the new parameter is invalid given the dimensions of the data being operated on.
+Speed up and slow down may fail in these cases.
 
-3. Parent, indirectly scalable - these ops are sped up and slowed by down
-adjusting the throughputs of their child ops. 
+these ops have a parameter that impacts their
+throughput. They are sped up and slowed down by trying to adjust that parameter.
+In some cases, it may not be possible to set the parameter to the certain values
+as this would make the op invalid given the dimensions of the data being
+operated on. Speed up and slow down may fail in these cases.
 
-4. Parent, directly scalable - these ops are sped up and slowed down by first
-trying to adjust their rate. If that is not possible, speedUp and slowDown
-try to adjust the throughputs of their child ops.
+3. Parent, indirectly scalable - Since these aren't directly scalable, they are
+sped up and slowed down by trying to scale their children.
+
+4. Parent, directly scalable - Since these are directly scalable, they are sped
+up and slowed down by trying to adjust their throughput parameters. If that is
+not possible (for the same reasons as case #2), then speed up and slow down try
+to scale the throughputs of their child ops.
 -}
 module Aetherling.Passes.ThroughputModifications (speedUp, slowDown) where
 import Aetherling.Operations.Types

--- a/src/Core/Aetherling/Passes/ThroughputModifications.hs
+++ b/src/Core/Aetherling/Passes/ThroughputModifications.hs
@@ -2,9 +2,12 @@
 Module: Aetherling.Passes.ThroughputModifications
 Description: Passes that tradeoff throughput and area
 
-The Aetherling Operations.
+The two main passes that modify the throughput of Aetherling operations are
+speedup and slowdown. These increase and decrease the throughput of the
+operations while preserving the order and values of inputs and outputs.
 
-Ops are split using two sets of categories:
+For the purposes of speedup and slowdown, Aetherling ops are split using two
+sets of categories:
 
 1. Parent or Leaf - An op is a parent op if it contains child ops. An op is
 a leaf op if it does not contain child ops. This is the same terminology as

--- a/src/Core/Aetherling/Passes/ThroughputModifications.hs
+++ b/src/Core/Aetherling/Passes/ThroughputModifications.hs
@@ -80,10 +80,13 @@ attemptSpeedUp :: Int -> Op -> (Op, Int)
 -- LEAF, INDIRECTLY SCALABLE 
 -- can't change throughput parameter, can't speed up child ops, so just wrap in
 -- a map to parallelize
--- ASSUMPTION: the user has specified a type for these ops and passes will not
--- change the type because that would change the semantics of the
--- program. For example, one could speed up an Add T_Int my making it a
--- Add $ T_Array 2 T_Int, but that would change the program's meaning.
+-- ASSUMPTION: the user has specified a basic unit of data that these types
+-- operate over. changing this data type will change the meaning of the program.
+-- For example, operating over 3 color channel, 8 bit depth image data should
+-- has a base type of T_Array 3 (T_Array 8 T_Bit). Speed up and slow down will
+-- not change the type because that would change the semantics of the program.
+-- The passes will make the program handle greater of fewer of these RGB pixels
+-- per clock.
 attemptSpeedUp requestedMult op@(Add _) = (MapOp requestedMult op, requestedMult)
 attemptSpeedUp requestedMult op@(Sub _) = (MapOp requestedMult op, requestedMult)
 attemptSpeedUp requestedMult op@(Mul _) = (MapOp requestedMult op, requestedMult)

--- a/src/Core/Aetherling/Passes/ThroughputModifications.hs
+++ b/src/Core/Aetherling/Passes/ThroughputModifications.hs
@@ -55,11 +55,11 @@ import Aetherling.Analysis.Metrics
 -- | Increase the throughput of an Aetherling DAG by increasing area and
 -- utilization. speedUp attempts to increase throughput by increasing
 -- utilization before using more area.
-speedUp throughMult op | actualMult == throughMult = spedUpOp
-  where (spedUpOp, actualMult) = attemptSpeedUp throughMult op
-speedUp throughMult op = Failure
-  (InvalidThroughputModification throughMult actualMult) 
-  where (spedUpOp, actualMult) = attemptSpeedUp throughMult op
+speedUp requestedMult op | actualMult == requestedMult = spedUpOp
+  where (spedUpOp, actualMult) = attemptSpeedUp requestedMult op
+speedUp requestedMult op = Failure
+  (InvalidThroughputModification requestedMult actualMult) 
+  where (spedUpOp, actualMult) = attemptSpeedUp requestedMult op
 
 -- This is the helper function that speeds up an op as much as possible
 -- and returns the amount sped up.
@@ -73,26 +73,26 @@ attemptSpeedUp :: Int -> Op -> (Op, Int)
 -- change the type because that would change the semantics of the
 -- program. For example, one could speed up an Add T_Int my making it a
 -- Add $ T_Array 2 T_Int, but that would change the program's meaning.
-attemptSpeedUp throughMult op@(Add _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Sub _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Mul _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Div _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Max _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Min _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Ashr _ _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Shl _ _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Abs _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Not _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(And _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Or  _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(XOr _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@Eq = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@Neq = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@Lt = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@Leq = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@Gt = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@Geq = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(LUT _) = (MapOp throughMult op, throughMult)
+attemptSpeedUp requestedMult op@(Add _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Sub _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Mul _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Div _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Max _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Min _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Ashr _ _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Shl _ _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Abs _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Not _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(And _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Or  _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(XOr _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@Eq = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@Neq = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@Lt = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@Leq = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@Gt = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@Geq = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(LUT _) = (MapOp requestedMult op, requestedMult)
 
 -- Must map over these because making a single memory wider is a more
 -- expensive operation than banking it (making multiple copies)
@@ -102,20 +102,20 @@ attemptSpeedUp throughMult op@(LUT _) = (MapOp throughMult op, throughMult)
 -- maping over a MemRead/MemWrite is banking it, and wrapping
 -- the type with an array is making a single memory read/write more
 -- per clock.
-attemptSpeedUp throughMult op@(MemRead _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(MemWrite _) = (MapOp throughMult op, throughMult)
+attemptSpeedUp requestedMult op@(MemRead _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(MemWrite _) = (MapOp requestedMult op, requestedMult)
 
 -- These are leaf, non-modifiable rate unlike SequenceArrayRepack because,
 -- for these operations, the user has not specified the type separately from the
 -- array length. Therefore, speedup may modify the meaning of the program
 -- by changing the types of these ops.
-attemptSpeedUp throughMult op@(ArrayReshape _ _) =
-  (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(DuplicateOutputs _ _) =
-  (MapOp throughMult op, throughMult)
+attemptSpeedUp requestedMult op@(ArrayReshape _ _) =
+  (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(DuplicateOutputs _ _) =
+  (MapOp requestedMult op, requestedMult)
 
-attemptSpeedUp throughMult op@(Constant_Int _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult op@(Constant_Bit _) = (MapOp throughMult op, throughMult)
+attemptSpeedUp requestedMult op@(Constant_Int _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult op@(Constant_Bit _) = (MapOp requestedMult op, requestedMult)
 
 -- LEAF, MODIFIABLE RATE
 -- If possible, speed up by changing the rate. Otherwise, just try to return
@@ -138,39 +138,39 @@ attemptSpeedUp throughMult op@(Constant_Bit _) = (MapOp throughMult op, throughM
 -- NOTE: increaseLBPxPerClock expects dimensions from innermost to outermost
 -- and LineBuffer stores them in the opposite order. Thus, they must be
 -- reversed when calling the helper function.
-attemptSpeedUp throughMult (LineBuffer p w img t bc) =
+attemptSpeedUp requestedMult (LineBuffer p w img t bc) =
   (LineBuffer (reverse reversedNewP) w img t bc, actualMult)
   where
     (reversedNewP, actualMult) =
-      increaseLBPxPerClock (reverse p) (reverse img) throughMult
+      increaseLBPxPerClock (reverse p) (reverse img) requestedMult
 
 -- could decrease sLenIn and sLenOut as increase throughput, but not going
 -- to do that as don't want to deal with fractional sequence lengths,
 -- which could happen if dividing sLenIn or sLenOut 
-attemptSpeedUp throughMult (SequenceArrayRepack (sLenIn, oldArrLenIn)
+attemptSpeedUp requestedMult (SequenceArrayRepack (sLenIn, oldArrLenIn)
                               (sLenOut, oldArrLenOut) t) =
-  (SequenceArrayRepack (sLenIn, oldArrLenIn * throughMult)
-    (sLenOut, oldArrLenOut * throughMult) t, throughMult)
+  (SequenceArrayRepack (sLenIn, oldArrLenIn * requestedMult)
+    (sLenOut, oldArrLenOut * requestedMult) t, requestedMult)
 
 
 -- PARENT, NON-MODIFIABLE RATE
 -- Speed up their child ops, no rate to modify on these, and no
 -- point in mapping over these as can just defer that to doing over children.
 
-attemptSpeedUp throughMult op@(NoOp _) = (MapOp throughMult op, throughMult)
-attemptSpeedUp throughMult (Delay d innerOp) =
+attemptSpeedUp requestedMult op@(NoOp _) = (MapOp requestedMult op, requestedMult)
+attemptSpeedUp requestedMult (Delay d innerOp) =
   (Delay d spedUpInnerOp, innerMult)
-  where (spedUpInnerOp, innerMult) = attemptSpeedUp throughMult innerOp 
+  where (spedUpInnerOp, innerMult) = attemptSpeedUp requestedMult innerOp 
 
-attemptSpeedUp throughMult (ComposePar ops) = 
+attemptSpeedUp requestedMult (ComposePar ops) = 
   let
-    spedUpOpsAndMults = map (attemptSpeedUp throughMult) ops
+    spedUpOpsAndMults = map (attemptSpeedUp requestedMult) ops
     spedUpOps = map fst spedUpOpsAndMults
     actualMults = map snd spedUpOpsAndMults
   in (ComposePar spedUpOps, minimum actualMults)
-attemptSpeedUp throughMult (ComposeSeq ops) = 
+attemptSpeedUp requestedMult (ComposeSeq ops) = 
   let
-    spedUpOpsAndMults = map (attemptSpeedUp throughMult) ops
+    spedUpOpsAndMults = map (attemptSpeedUp requestedMult) ops
     (hdSpedUpOps:tlSpedUpOps) = map fst spedUpOpsAndMults
     actualMults = map snd spedUpOpsAndMults
   -- doing a fold here instead of just making another composeSeq to make sure all
@@ -187,60 +187,60 @@ attemptSpeedUp throughMult (ComposeSeq ops) =
 -- changing par and making more copies. Making two independent copies with
 -- different state won't behave same as modifying op to update its state to run
 -- twice as fast
-attemptSpeedUp throughMult (MapOp par innerOp) | not $ hasInternalState innerOp =
-  (MapOp (par*throughMult) innerOp, throughMult)
-attemptSpeedUp throughMult (MapOp par innerOp) =
-  let (spedUpInnerOp, actualMult) = attemptSpeedUp throughMult innerOp
+attemptSpeedUp requestedMult (MapOp par innerOp) | not $ hasInternalState innerOp =
+  (MapOp (par*requestedMult) innerOp, requestedMult)
+attemptSpeedUp requestedMult (MapOp par innerOp) =
+  let (spedUpInnerOp, actualMult) = attemptSpeedUp requestedMult innerOp
   in (MapOp par spedUpInnerOp, actualMult)
 
 -- speed up reduce based on three cases:
 -- 1. child op has internal state: just speed up child op.
 -- Due to state, can't make multiple copies of child op for same reason as map
--- 2. child op has no internal state and throughMult has value so that
+-- 2. child op has no internal state and requestedMult has value so that
 -- afterwards numComb >= newPar: increase parallelism factor to desired amount
 -- ASSUMPTION: newPar must cleanly divide into numComb, or numComb % newPar == 0
--- 3. child op has no internal state and throughMult has value so that afterwards
+-- 3. child op has no internal state and requestedMult has value so that afterwards
 -- numComb < newPar: make par == numComb and map over reduce to get rest
 -- of parallelism
 -- ASSUMPTION: numComb must cleanly divide into newPar, or
 -- newPar % numComb == 0
 -- 4. Child has no internal state, but the other conditions don't hold: speed up
 -- the child
-attemptSpeedUp throughMult (ReduceOp par numComb innerOp) |
+attemptSpeedUp requestedMult (ReduceOp par numComb innerOp) |
   (not $ hasInternalState innerOp) &&
   ((newPar <= numComb) && ((numComb `mod` newPar) == 0)) =
-  (ReduceOp newPar numComb innerOp, throughMult)
-  where newPar = par*throughMult
-attemptSpeedUp throughMult (ReduceOp par numComb innerOp) |
+  (ReduceOp newPar numComb innerOp, requestedMult)
+  where newPar = par*requestedMult
+attemptSpeedUp requestedMult (ReduceOp par numComb innerOp) |
   (not $ hasInternalState innerOp) &&
   ((newPar > numComb) && ((newPar `mod` numComb) == 0)) =
-  (MapOp mapPar $ ReduceOp numComb numComb innerOp, throughMult)
+  (MapOp mapPar $ ReduceOp numComb numComb innerOp, requestedMult)
   where
-    newPar = par*throughMult
-    mapPar = throughMult `ceilDiv` (numComb `ceilDiv` par)
-attemptSpeedUp throughMult (ReduceOp par numComb innerOp) =
-  let (spedUpInnerOp, actualMult) = attemptSpeedUp throughMult innerOp
+    newPar = par*requestedMult
+    mapPar = requestedMult `ceilDiv` (numComb `ceilDiv` par)
+attemptSpeedUp requestedMult (ReduceOp par numComb innerOp) =
+  let (spedUpInnerOp, actualMult) = attemptSpeedUp requestedMult innerOp
   in (ReduceOp par numComb spedUpInnerOp, actualMult)
 
 -- cases:
--- 1. if throughMult less than denom and throughMult divides cleanly
--- into denom, just decrease the underutil denom
--- 2. if throughMult greater than denom and denom divides cleanly into
--- throughMult, remove the underutil and speed up the innerOp using the
--- remaining part of throughMult
+-- 1. if requestedMult less than or equal to than denom and requestedMult
+-- divides cleanly into denom, just decrease the underutil denom
+-- 2. if requestedMult greater than denom and denom divides cleanly into
+-- requestedMult, remove the underutil and speed up the innerOp using the
+-- remaining part of requestedMult
 -- 3. fall back, just speed up the inner op
-attemptSpeedUp throughMult (Underutil denom op) |
-  (denom `mod` throughMult) == 0 =
-  (Underutil (denom `ceilDiv` throughMult) op, throughMult)
-attemptSpeedUp throughMult (Underutil denom op) |
-  (throughMult `mod` denom) == 0 =
+attemptSpeedUp requestedMult (Underutil denom op) |
+  (denom `mod` requestedMult) == 0 =
+  (Underutil (denom `ceilDiv` requestedMult) op, requestedMult)
+attemptSpeedUp requestedMult (Underutil denom op) |
+  (requestedMult `mod` denom) == 0 =
   (spedUpOp, denom*innerMult)
   where
-    remainingMult = throughMult `ceilDiv` denom
+    remainingMult = requestedMult `ceilDiv` denom
     (spedUpOp, innerMult) = attemptSpeedUp remainingMult op 
-attemptSpeedUp throughMult op@(Underutil denom innerOp) =
+attemptSpeedUp requestedMult op@(Underutil denom innerOp) =
   (Underutil denom innerSpedUpOp, innerMult)
-  where (innerSpedUpOp, innerMult) = attemptSpeedUp throughMult innerOp
+  where (innerSpedUpOp, innerMult) = attemptSpeedUp requestedMult innerOp
 
 attemptSpeedUp _ op@(Failure _) = (op, 1)
 
@@ -309,10 +309,10 @@ increaseLBPxPerClock p _ _ = (p, 1)
 -- | Decrease the throughput an Aetherling DAG by decreasing area and
 -- utilization. slowDown attempts to decrease throughput by decreasing area
 -- before underutilizing.
-slowDown throughDiv op | actualDiv == throughDiv = spedUpOp
-  where (spedUpOp, actualDiv) = attemptSlowDown throughDiv op
-slowDown throughDiv op = Failure $ InvalidThroughputModification throughDiv actualDiv
-  where (spedUpOp, actualDiv) = attemptSlowDown throughDiv op
+slowDown requestedDiv op | actualDiv == requestedDiv = spedUpOp
+  where (spedUpOp, actualDiv) = attemptSlowDown requestedDiv op
+slowDown requestedDiv op = Failure $ InvalidThroughputModification requestedDiv actualDiv
+  where (spedUpOp, actualDiv) = attemptSlowDown requestedDiv op
 
 -- This is the helper function that slows down an op as much as possible
 -- and returns the amount slowed down.
@@ -322,41 +322,41 @@ slowDown throughDiv op = Failure $ InvalidThroughputModification throughDiv actu
 -- slow down. This is the same approach as speed up, but with underutil instead
 -- of map, with same assumption regarding not changing the type.
 attemptSlowDown :: Int -> Op -> (Op, Int)
-attemptSlowDown throughDiv op@(Add _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Sub _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Mul _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Div _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Max _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Min _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Ashr _ _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Shl _ _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Abs _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Not _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(And _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Or  _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(XOr _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@Eq = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@Neq = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@Lt = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@Leq = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@Gt = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@Geq = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(LUT _) = (MapOp throughDiv op, throughDiv)
+attemptSlowDown requestedDiv op@(Add _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Sub _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Mul _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Div _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Max _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Min _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Ashr _ _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Shl _ _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Abs _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Not _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(And _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Or  _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(XOr _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@Eq = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@Neq = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@Lt = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@Leq = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@Gt = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@Geq = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(LUT _) = (MapOp requestedDiv op, requestedDiv)
 
 -- underutil instead of changing type for same reason as speedUp using map,
 -- want to do banking instead of making wider memories
-attemptSlowDown throughDiv op@(MemRead _) = (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(MemWrite _) = (Underutil throughDiv op, throughDiv)
+attemptSlowDown requestedDiv op@(MemRead _) = (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(MemWrite _) = (Underutil requestedDiv op, requestedDiv)
 
-attemptSlowDown throughDiv op@(ArrayReshape _ _) =
-  (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(DuplicateOutputs _ _) =
-  (Underutil throughDiv op, throughDiv)
+attemptSlowDown requestedDiv op@(ArrayReshape _ _) =
+  (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(DuplicateOutputs _ _) =
+  (Underutil requestedDiv op, requestedDiv)
 
-attemptSlowDown throughDiv op@(Constant_Int _) =
-  (Underutil throughDiv op, throughDiv)
-attemptSlowDown throughDiv op@(Constant_Bit _) =
-  (Underutil throughDiv op, throughDiv)
+attemptSlowDown requestedDiv op@(Constant_Int _) =
+  (Underutil requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv op@(Constant_Bit _) =
+  (Underutil requestedDiv op, requestedDiv)
 
 -- LEAF, MODIFIABLE RATE
 -- If possible, slow down by changing the rate. Otherwise, just try to return
@@ -372,38 +372,38 @@ attemptSlowDown throughDiv op@(Constant_Bit _) =
 -- see decreaseLBPxPerClock for more information
 -- NOTE: decreaseLBPxPerClock expects dimensions from outermost to innermost
 -- which matches the order for LineBuffer.
-attemptSlowDown throughDiv (LineBuffer p w img t bc) =
+attemptSlowDown requestedDiv (LineBuffer p w img t bc) =
   (LineBuffer newP w img t bc, actualDiv)
   where
-    (newP, actualDiv) = decreaseLBPxPerClock p img throughDiv
+    (newP, actualDiv) = decreaseLBPxPerClock p img requestedDiv
 
 -- not going to change SLen in consistency with speed up
--- can only slow down if both array lengths are divisible by throughDiv
-attemptSlowDown throughDiv (SequenceArrayRepack (sLenIn, oldArrLenIn)
+-- can only slow down if both array lengths are divisible by requestedDiv
+attemptSlowDown requestedDiv (SequenceArrayRepack (sLenIn, oldArrLenIn)
                               (sLenOut, oldArrLenOut) t) |
-  (oldArrLenIn `mod` throughDiv == 0) && (oldArrLenOut `mod` throughDiv == 0) =
-  (SequenceArrayRepack (sLenIn, oldArrLenIn `ceilDiv` throughDiv)
-    (sLenOut, oldArrLenOut `ceilDiv` throughDiv) t, throughDiv)
-attemptSlowDown throughDiv op@(SequenceArrayRepack _ _ _) = (op, 1)
+  (oldArrLenIn `mod` requestedDiv == 0) && (oldArrLenOut `mod` requestedDiv == 0) =
+  (SequenceArrayRepack (sLenIn, oldArrLenIn `ceilDiv` requestedDiv)
+    (sLenOut, oldArrLenOut `ceilDiv` requestedDiv) t, requestedDiv)
+attemptSlowDown requestedDiv op@(SequenceArrayRepack _ _ _) = (op, 1)
 
 -- PARENT, NON-MODIFIABLE RATE
 -- Slow their child ops, no rate to modify on these, and no
 -- point in underutiling these as can just defer that to children.
 
-attemptSlowDown throughDiv op@(NoOp _) = (MapOp throughDiv op, throughDiv)
-attemptSlowDown throughDiv (Delay d innerOp) =
+attemptSlowDown requestedDiv op@(NoOp _) = (MapOp requestedDiv op, requestedDiv)
+attemptSlowDown requestedDiv (Delay d innerOp) =
   (Delay d slowedInnerOp, innerMult)
-  where (slowedInnerOp, innerMult) = attemptSlowDown throughDiv innerOp 
+  where (slowedInnerOp, innerMult) = attemptSlowDown requestedDiv innerOp 
 
-attemptSlowDown throughDiv (ComposePar ops) = 
+attemptSlowDown requestedDiv (ComposePar ops) = 
   let
-    slowedOpsAndMults = map (attemptSlowDown throughDiv) ops
+    slowedOpsAndMults = map (attemptSlowDown requestedDiv) ops
     slowedOps = map fst slowedOpsAndMults
     actualDivs = map snd slowedOpsAndMults
   in (ComposePar slowedOps, maximum actualDivs)
-attemptSlowDown throughDiv (ComposeSeq ops) = 
+attemptSlowDown requestedDiv (ComposeSeq ops) = 
   let
-    slowedOpsAndMults = map (attemptSlowDown throughDiv) ops
+    slowedOpsAndMults = map (attemptSlowDown requestedDiv) ops
     (hdSlowedOps:tlSlowedOps) = map fst slowedOpsAndMults
     actualDivs = map snd slowedOpsAndMults
   -- doing a fold here instead of just making another composeSeq to make sure all
@@ -419,11 +419,11 @@ attemptSlowDown throughDiv (ComposeSeq ops) =
 -- If child has internal state, can't automatically slow down child as changing
 -- number of child ops is different from running each one at a lower rate when
 -- each child op is managing state. This is the same reasoning as speed up.
-attemptSlowDown throughDiv (MapOp par innerOp) | not $ hasInternalState innerOp &&
-  (par `mod` throughDiv == 0) =
-  (MapOp (par `ceilDiv` throughDiv) innerOp, throughDiv)
-attemptSlowDown throughDiv (MapOp par innerOp) =
-  let (slowedInnerOp, actualDiv) = attemptSlowDown throughDiv innerOp
+attemptSlowDown requestedDiv (MapOp par innerOp) | not $ hasInternalState innerOp &&
+  (par `mod` requestedDiv == 0) =
+  (MapOp (par `ceilDiv` requestedDiv) innerOp, requestedDiv)
+attemptSlowDown requestedDiv (MapOp par innerOp) =
+  let (slowedInnerOp, actualDiv) = attemptSlowDown requestedDiv innerOp
   in (MapOp par slowedInnerOp, actualDiv)
 
 -- slow down reduce based on three cases:
@@ -431,22 +431,22 @@ attemptSlowDown throughDiv (MapOp par innerOp) =
 -- Due to state, can't change number of copies of child op for same reason as map
 -- 2. child op has no internal state: decrease parallelism factor to desired
 -- amount
--- ASSUMPTION: throughDiv must cleanly divide into Par, or par % throughDiv == 0
+-- ASSUMPTION: requestedDiv must cleanly divide into Par, or par % requestedDiv == 0
 -- ASSUMPTION: newPar must cleanly divide into numComb, or numComb % newPar == 0
 -- 3. child op has no internal state but other conditions don't hold: slow down
 -- the child op
-attemptSlowDown throughDiv (ReduceOp par numComb innerOp) |
+attemptSlowDown requestedDiv (ReduceOp par numComb innerOp) |
   (not $ hasInternalState innerOp) &&
-  (par `mod` throughDiv == 0) &&
+  (par `mod` requestedDiv == 0) &&
   (numComb `mod` newPar == 0) =
-  (ReduceOp newPar numComb innerOp, throughDiv)
-  where newPar = par `ceilDiv` throughDiv
-attemptSlowDown throughDiv (ReduceOp par numComb innerOp) =
-  let (slowedInnerOp, actualDiv) = attemptSlowDown throughDiv innerOp
+  (ReduceOp newPar numComb innerOp, requestedDiv)
+  where newPar = par `ceilDiv` requestedDiv
+attemptSlowDown requestedDiv (ReduceOp par numComb innerOp) =
+  let (slowedInnerOp, actualDiv) = attemptSlowDown requestedDiv innerOp
   in (ReduceOp par numComb slowedInnerOp, actualDiv)
 
-attemptSlowDown throughDiv (Underutil denom op) =
-  (Underutil (denom * throughDiv) op, throughDiv)
+attemptSlowDown requestedDiv (Underutil denom op) =
+  (Underutil (denom * requestedDiv) op, requestedDiv)
 
 attemptSlowDown _ op@(Failure _) = (op, 1)
 

--- a/src/Core/Aetherling/Passes/ThroughputModifications.hs
+++ b/src/Core/Aetherling/Passes/ThroughputModifications.hs
@@ -30,6 +30,7 @@ and can have its throughput modified by changing parallelism.
 The four groups are have their throughputs increased and decreased using
 different approaches:
 
+MAYBE I SHOULD CALL THESE "Leaf, directly scalable"
 1. Leaf, non-modifiable rate - these ops are sped up and slowed down by wrapping
 them in a parent, modifiable rate op such as map and underutil. 
 
@@ -144,6 +145,10 @@ attemptSpeedUp requestedMult (LineBuffer p w img t bc) =
     (reversedNewP, actualMult) =
       increaseLBPxPerClock (reverse p) (reverse img) requestedMult
 
+-- speeding up SequenceArrayRepack means handling streams with
+-- more bits per element of the stream.
+-- For example, attemptSpeedUp 2 $ SequenceArrayRepack (4, 1) (2, 2) T_Int ==
+-- SequenceArrayRepack (4, 2) (2, 4) T_Int
 -- could decrease sLenIn and sLenOut as increase throughput, but not going
 -- to do that as don't want to deal with fractional sequence lengths,
 -- which could happen if dividing sLenIn or sLenOut 
@@ -378,6 +383,10 @@ attemptSlowDown requestedDiv (LineBuffer p w img t bc) =
   where
     (newP, actualDiv) = decreaseLBPxPerClock p img requestedDiv
 
+-- slowing down SequenceArrayRepack means handling streams with
+-- fewer bits per element of the stream.
+-- For example, attemptSlowDown 2 $ SequenceArrayRepack (4, 2) (2, 4) T_Int ==
+-- SequenceArrayRepack (4, 1) (2, 2) T_Int
 -- not going to change SLen in consistency with speed up
 -- can only slow down if both array lengths are divisible by requestedDiv
 attemptSlowDown requestedDiv (SequenceArrayRepack (sLenIn, oldArrLenIn)

--- a/src/Core/Aetherling/Passes/ThroughputModifications.hs
+++ b/src/Core/Aetherling/Passes/ThroughputModifications.hs
@@ -2,7 +2,20 @@
 Module: Aetherling.Passes.ThroughputModifications
 Description: Passes that tradeoff throughput and area
 
-The Aetherling Operations. These are split into four groups:
+The Aetherling Operations.
+
+Ops are split using two sets of categories:
+
+1. Parent or Leaf - An op is a parent op if it contains child ops. An op is
+a leaf op if it does not contain child ops. This is the same terminology as
+all other tree data structures.
+
+2. Directly or indirectly scalable - An op is directly scalable if it has a
+parameter for directly scaling its throughput. An op is indirectly scalable
+if it does not have such a parameter. Indirectly scalable ops are scaled
+either by wrapping them in other ops or by scaling their child ops.
+
+These categories form four groups:
 
 1. Leaf, indirectly scalable - These ops both do not contain any child ops and
 also do not have a parameter for directly scaling their throughput. Examples of

--- a/src/Core/Aetherling/Passes/ThroughputModifications.hs
+++ b/src/Core/Aetherling/Passes/ThroughputModifications.hs
@@ -197,7 +197,8 @@ attemptSpeedUp requestedMult (MapOp par innerOp) =
 -- 1. child op has internal state: just speed up child op.
 -- Due to state, can't make multiple copies of child op for same reason as map
 -- 2. child op has no internal state and requestedMult has value so that
--- afterwards numComb >= newPar: increase parallelism factor to desired amount
+-- numComb >= the amount of parallelism post speed up (newPar):
+-- increase parallelism factor to desired amount
 -- ASSUMPTION: newPar must cleanly divide into numComb, or numComb % newPar == 0
 -- 3. child op has no internal state and requestedMult has value so that afterwards
 -- numComb < newPar: make par == numComb and map over reduce to get rest
@@ -432,7 +433,8 @@ attemptSlowDown requestedDiv (MapOp par innerOp) =
 -- 2. child op has no internal state: decrease parallelism factor to desired
 -- amount
 -- ASSUMPTION: requestedDiv must cleanly divide into Par, or par % requestedDiv == 0
--- ASSUMPTION: newPar must cleanly divide into numComb, or numComb % newPar == 0
+-- ASSUMPTION: The amount of parallelism post slow down (newPar) must cleanly
+-- divide into numComb, or numComb % newPar == 0
 -- 3. child op has no internal state but other conditions don't hold: slow down
 -- the child op
 attemptSlowDown requestedDiv (ReduceOp par numComb innerOp) |

--- a/src/Core/Aetherling/Simulator/MapReduce.hs
+++ b/src/Core/Aetherling/Simulator/MapReduce.hs
@@ -90,23 +90,23 @@ simhlMapFoldLambda simhl lastTuple laneInput =
 --   makes one output.
 --   2. A register whose input is the output of a reducedOp, which itself
 --   takes the output of said register and the tree as inputs (this part
---   can be omitted if numComb == par, i.e. the reduce is combinational.
+--   can be omitted if numTokens == par, i.e. the reduce is combinational.
 --   (assuming combinational reducedOp).
--- After (numComb/par) cycles, the reg's input contains the result of reducing
--- numComb inputs. The reg should be cleared for the next set of numComb inputs.
+-- After (numTokens/par) cycles, the reg's input contains the result of reducing
+-- numTokens inputs. The reg should be cleared for the next set of numTokens inputs.
 simhlReduce :: Simhl -> Int -> Int -> Op -> [[ValueType]] -> SimhlState
             -> ( [[ValueType]], SimhlState )
-simhlReduce simhl par numComb theReducedOp inStrs inState
-  | numComb `mod` par /= 0 || numComb == 0 =
+simhlReduce simhl par numTokens theReducedOp inStrs inState
+  | numTokens `mod` par /= 0 || numTokens == 0 =
       error("Simulator assumes paralellism of a reduce evenly divides "
             ++ "its nonzero combine count (simulating "
-            ++ show (ReduceOp par numComb theReducedOp)
+            ++ show (ReduceOp numTokens par theReducedOp)
             ++ ")")
   | (length $ inPorts theReducedOp) /= 2 ||
     (length $ outPorts theReducedOp) /= 1 =
       error("Simulator assumes ReduceOp op has 2 inputs/1 output. "
              ++ "simulating ("
-             ++ show (ReduceOp par numComb theReducedOp)
+             ++ show (ReduceOp numTokens par theReducedOp)
              ++ ")")
   | otherwise =
     let
@@ -114,9 +114,9 @@ simhlReduce simhl par numComb theReducedOp inStrs inState
       (treeOutStr, outState)
           = simhlReduceTree simhl theReducedOp laneInStrs inState
     in
-      if par == numComb
+      if par == numTokens
       then ([treeOutStr], outState) -- Part 2 device unused.
-      else ([simhlReduceReg simhl par numComb theReducedOp treeOutStr], outState)
+      else ([simhlReduceReg simhl par numTokens theReducedOp treeOutStr], outState)
       -- We have to put the output stream in a 1-list for the 1
       -- output port of ReduceOp.
 
@@ -179,25 +179,25 @@ simhlReduceTreeLevel simhl theReducedOp inLanes _ = error(
 -- ReduceOp device. Takes a stream of tree outputs and produces the
 -- stream of outputs that would come out the full ReduceOp by
 -- reducing each subsequence of N tree outputs to 1 output, where N =
--- numComb/par.
+-- numTokens/par.
 --
 -- We have to assume that theReduceOp is combinational here, so take
 -- some liberties in calling it over-and-over again and hiding
 -- SimhlState from it.
 simhlReduceReg :: Simhl -> Int -> Int -> Op -> [ValueType] -> [ValueType]
 simhlReduceReg _ _ _ _ [] = []
-simhlReduceReg simhl par numComb theReducedOp treeOutStr =
-    if par == 0 || numComb == 0 || numComb `mod` par /= 0
-    then error "Aetherling internal error: check reduce par/numComb."
+simhlReduceReg simhl par numTokens theReducedOp treeOutStr =
+    if par == 0 || numTokens == 0 || numTokens `mod` par /= 0
+    then error "Aetherling internal error: check reduce par/numTokens."
     else
       let
-        cyclesNeeded = numComb `div` par
+        cyclesNeeded = numTokens `div` par
         (nowReduce, laterReduce) = splitAt cyclesNeeded treeOutStr
       in
         if length nowReduce < cyclesNeeded
         then []
         else (reduceList nowReduce):
-             (simhlReduceReg simhl par numComb theReducedOp laterReduce)
+             (simhlReduceReg simhl par numTokens theReducedOp laterReduce)
   -- Reduce a subsequence of the tree output stream (subseq length =
   -- cycles needed per output) into one output. Use foldl since it's
   -- the same order the actual circuit will evaluate the outputs
@@ -245,13 +245,13 @@ simhlPreMap _ _ _ _ = error "Aetherling internal error: expected MapOp"
 
 simhlPreReduce :: SimhlPre -> [Op] -> [Maybe Int] -> SimhlPreState
                -> ([Maybe Int], SimhlPreState)
-simhlPreReduce simhlPre opStack@(ReduceOp par numComb op:_) inStrLens inState
+simhlPreReduce simhlPre opStack@(ReduceOp numTokens par op:_) inStrLens inState
     | length (inPorts op) /= 2 || length (outPorts op) /= 1 =
       error("Simulator assumes reducedOp has 2 inputs and 1 output, at\n"
          ++ simhlFormatOpStack opStack
       )
-    | numComb `mod` par /= 0 =
-      error("Need numComb to be divisible by paralellism at "
+    | numTokens `mod` par /= 0 =
+      error("Need numTokens to be divisible by paralellism at "
          ++ simhlFormatOpStack opStack
       )
     | fst (simhlPre (op:opStack) (replicate 2 (head inStrLens)) inState)
@@ -269,7 +269,7 @@ simhlPreReduce simhlPre opStack@(ReduceOp par numComb op:_) inStrLens inState
         -- checked above that it has predictable behavior on its
         -- output port lengths.
         inStrLen = head inStrLens
-        ratio = numComb `div` par
+        ratio = numTokens `div` par
         outStrLen' Nothing = Nothing
         outStrLen' (Just x) = Just $ x `div` ratio
         outStrLen = outStrLen' $ inStrLen

--- a/src/Core/Aetherling/Simulator/MapReduce.hs
+++ b/src/Core/Aetherling/Simulator/MapReduce.hs
@@ -96,7 +96,7 @@ simhlMapFoldLambda simhl lastTuple laneInput =
 -- numTokens inputs. The reg should be cleared for the next set of numTokens inputs.
 simhlReduce :: Simhl -> Int -> Int -> Op -> [[ValueType]] -> SimhlState
             -> ( [[ValueType]], SimhlState )
-simhlReduce simhl par numTokens theReducedOp inStrs inState
+simhlReduce simhl numTokens par theReducedOp inStrs inState
   | numTokens `mod` par /= 0 || numTokens == 0 =
       error("Simulator assumes paralellism of a reduce evenly divides "
             ++ "its nonzero combine count (simulating "

--- a/src/Core/Aetherling/Simulator/Simulator.hs
+++ b/src/Core/Aetherling/Simulator/Simulator.hs
@@ -170,8 +170,8 @@ simhl (LineBuffer pixelRate windowSize imageSize t bc) inStrs state =
 simhl op@(DuplicateOutputs _ _) inStrs inState =
     simhlDuplicateOutputs simhl op inStrs inState
 simhl (MapOp par op) inStrs state = simhlMap simhl par op inStrs state
-simhl (ReduceOp par numComb op) inStrs state =
-    simhlReduce simhl par numComb op inStrs state
+simhl (ReduceOp numTokens par op) inStrs state =
+    simhlReduce simhl par numTokens op inStrs state
 
 -- We only care about meaningful inputs and outputs.  Therefore,
 -- underutil and register delays should be no-ops in this high level

--- a/src/Core/Aetherling/Simulator/Simulator.hs
+++ b/src/Core/Aetherling/Simulator/Simulator.hs
@@ -171,7 +171,7 @@ simhl op@(DuplicateOutputs _ _) inStrs inState =
     simhlDuplicateOutputs simhl op inStrs inState
 simhl (MapOp par op) inStrs state = simhlMap simhl par op inStrs state
 simhl (ReduceOp numTokens par op) inStrs state =
-    simhlReduce simhl par numTokens op inStrs state
+    simhlReduce simhl numTokens par op inStrs state
 
 -- We only care about meaningful inputs and outputs.  Therefore,
 -- underutil and register delays should be no-ops in this high level

--- a/test/TestSimulator.hs
+++ b/test/TestSimulator.hs
@@ -230,7 +230,7 @@ simhlCase2 = SimhlTestCase
   []
 
 -- Check that every entry of a 5-array is even.
--- This tests the combinational case of ReduceOp (par = numComb).
+-- This tests the combinational case of ReduceOp (par = numTokens).
 simhlAllEvenOp =
   (simhlNoOp [T_Array 5 T_Int] |&| Constant_Int [1,1,1,1,1]) |>>=|
   (And (T_Array 5 T_Int)   |&| Constant_Int [1]) |>>=|
@@ -273,7 +273,7 @@ simhlMul7Max15SpaceOp =
   (Underutil 5 (ArrayReshape (replicate 15 T_Int) [T_Array 15 T_Int])) |>>=|
   (SequenceArrayRepack (1, 15) (5, 3) T_Int |&| Underutil 5 (Constant_Int [7]))
   |>>=|
-  (ReduceOp 3 15 (Max T_Int) |&| Underutil 5 (simhlUnbox T_Int))
+  (ReduceOp 15 3 (Max T_Int) |&| Underutil 5 (simhlUnbox T_Int))
   |>>=|
   Underutil 5 (Mul T_Int)
 simhlMul7Max15Combinational :: [ValueType] -> [ValueType]
@@ -290,7 +290,7 @@ simhlCase5 = SimhlTestCase
 -- Same thing, but take 15 inputs sequentially.
 simhlMul7Max15TimeOp =
   (simhlBox T_Int |&| Underutil 15 (Constant_Int [7])) |>>=|
-  (ReduceOp 1 15 (Max T_Int) |&| Underutil 15 (simhlUnbox T_Int)) |>>=|
+  (ReduceOp 15 1 (Max T_Int) |&| Underutil 15 (simhlUnbox T_Int)) |>>=|
   Underutil 15 (Mul T_Int)
 simhlMul7Max15TimeImpl :: [[ValueType]] -> [[ValueType]]
                        -> ( [[ValueType]], [[ValueType]] )

--- a/test/TestSimulator.hs
+++ b/test/TestSimulator.hs
@@ -360,7 +360,7 @@ simhlMemSumDiffMinImpl _ [xv:xvs, yv:yvs] =
 simhlMemSumDiffMinImpl _ _ = error "Aetherling test internal error: case 9"
 simhlCase9 = SimhlTestCase
   "Read numbers from two memory inputs, output sums and differences to \
-  \memory, minimums to an output port. (Tests RegRetime, \
+  \memory, mins to an output port. (Tests RegRetime, \
   \DuplicateOutputs, MemRead, MemWrite, Add, Sub, Min)"
   simhlMemSumDiffMinOp
   simhlMemSumDiffMinImpl


### PR DESCRIPTION
This PR mainly reworks ThroughputModifications.hs so that others can understand it. @kayvonf, this is the PR you are looking for.

This PR also reorders the arguments to ReduceOp and renames them, so ReduceOp 4 1 now means 4 tokens are reduced together (called numTokens) with 1 token received per clock (called parallelism or par).

@akeley98 - I had to reorder the args for reduce in simulator. Please confirm I did it the correct way.