### PR TITLE
Ready Valid Op

### DIFF
--- a/src/Apps/Aetherling/SimpleExamples.hs
+++ b/src/Apps/Aetherling/SimpleExamples.hs
@@ -29,6 +29,13 @@ lbChain =
   LineBuffer [1] [3] [300] T_Int Crop |>>=|
   LineBuffer [1] [3] [298] (T_Array 3 T_Int) Crop
 
+lbChainReadyValid =
+  readyValid (
+    Constant_Int [1] |>>=|
+    LineBuffer [1] [3] [300] T_Int Crop
+  ) |>>=|
+  readyValid (LineBuffer [1] [3] [298] (T_Array 3 T_Int) Crop)
+
 -- no support for 2D linebuffers yet
 
 memReadInt = MemRead T_Int

--- a/src/Core/Aetherling/Analysis/Latency.hs
+++ b/src/Core/Aetherling/Analysis/Latency.hs
@@ -117,6 +117,7 @@ sequentialLatency (LogicalUtil ratio op) = phaseWhichCycle ratio (sequentialLate
 sequentialLatency (Register clks _ _) = clks
 sequentialLatency (ComposePar ops) = maximum (map sequentialLatency ops)
 sequentialLatency (ComposeSeq ops) = sum (map sequentialLatency ops)
+sequentialLatency (ReadyValid op) = sequentialLatency op -- Still useful for performance evaluation.
 sequentialLatency failure@(Failure _) =
   error("Failure type has no latency " ++ show failure)
 

--- a/src/Core/Aetherling/LineBufferManifestoModule.hs
+++ b/src/Core/Aetherling/LineBufferManifestoModule.hs
@@ -109,7 +109,7 @@ manifestoInPorts lb =
     if imgY `mod` yPerClk /= 0 || imgX `mod` xPerClk /= 0 then
       error "px/clk width/height must divide image width/height."
     else
-      [T_Port "I" seqLen arrayToken 1]
+      [T_Port "I" seqLen arrayToken 1 False]
 
 manifestoOutPorts :: ManifestoData -> [PortType]
 manifestoOutPorts lb =
@@ -134,7 +134,7 @@ manifestoOutPorts lb =
     else if xPerClk `mod` strideArea /= 0 && strideArea `mod` xPerClk /= 0 then
       error "Window throughput must be integer (or reciprocal of integer)."
     else
-      [T_Port "O" seqLen arrayToken 1]
+      [T_Port "O" seqLen arrayToken 1 False]
 
 manifestoCPS :: ManifestoData -> Int
 manifestoCPS lb =

--- a/src/Core/Aetherling/Operations/AST.hs
+++ b/src/Core/Aetherling/Operations/AST.hs
@@ -118,6 +118,11 @@ data Op =
   | ComposePar [Op]
   | ComposeSeq [Op]
   | Failure FailureType
+
+  -- Ready-valid meta-op.
+  -- Wraps the whole op with a ready-valid interface. Connections
+  -- between child ops within the wrapped op are not affected.
+  | ReadyValid Op
   deriving (Eq, Show)
 
 -- | The how to handle boundaries where LineBuffer emits invalid data.
@@ -149,7 +154,10 @@ data FailureType =
   deriving (Eq, Show)
 
 data ComposeResult = 
-  PriorFailure
+  PriorFailure 
+  -- | ReadyValidMismatch indicates that we tried to compose a synchronous op
+  -- with an op that has a ready-valid interface.
+  | ReadyValidMismatch
   | PortCountMismatch
   -- | TokenTypeMismatch indicates that we tried to glue two ports of
   -- different type together.
@@ -206,6 +214,7 @@ getChildOps (LogicalUtil _ op) = [op]
 getChildOps (Register _ _ _) = []
 getChildOps (ComposePar ops) = ops
 getChildOps (ComposeSeq ops) = ops
+getChildOps (ReadyValid op) = [op]
 getChildOps (Failure (ComposeFailure _ (op0, op1))) = [op0, op1]
 getChildOps (Failure _) = []
 

--- a/src/Core/Aetherling/Operations/Compose.hs
+++ b/src/Core/Aetherling/Operations/Compose.hs
@@ -2,10 +2,38 @@
 Module: Aetherling.Operations.Compose
 Description: Provides functions for composing Aetherling operations into a DAG
 -}
-module Aetherling.Operations.Compose where
+module Aetherling.Operations.Compose ((|.|), (|>>=|), (|&|)) where
 import Aetherling.Operations.Types
 import Aetherling.Operations.AST
+import Aetherling.Operations.ReadyValid
 import Aetherling.Analysis.PortsAndThroughput
+
+-- Rules for compose (Akeley's view)
+--
+-- For synchronous ops, the rule for ComposeSeq (a |>>=| b) is that
+-- the throughput and token type of each of a's output ports must
+-- match (in order) with each of b's input ports. For ComposePar (a
+-- |&| b), there are no restrictions. However, at the time of writing,
+-- we plan to view ComposePar as one unified unit, in the sense that
+-- we want it to act as a single device with a single latency. So, if
+-- a and b have vastly different latencies, one of those ops will be
+-- delayed significantly to match the other. (For this reason, when
+-- designing pipelines, prefer a ComposePar of ComposeSeq design over
+-- a ComposeSeq of ComposePar design, to minimize such matching
+-- delays).
+--
+-- For ready-valid ops, ComposeSeq only requires that each output port
+-- gets matched with an input port of the same token type, but not
+-- neccessarily the same (estimated) throughput. Of course it is still
+-- best for effeciency if the throughputs are nearly matched.
+--
+-- For both ComposePar and ComposeSeq, no ready-valid op can be
+-- composed with a non-ready-valid (synchronous) op. The synchronous
+-- op must be wrapped in a ReadyValid op. This is obviously needed for
+-- ComposeSeq. We also require this for ComposePar because, as before,
+-- we want to view a ComposePar as a single unit. It would be
+-- confusing then if some outputs were synchronous and some were
+-- ready-valid.
 
 -- | This is for making ComposeSeq
 (|.|) :: Op -> Op -> Op
@@ -14,37 +42,104 @@ import Aetherling.Analysis.PortsAndThroughput
 (|.|) op0 cf@(Failure _) = Failure $ ComposeFailure PriorFailure (cf, op0)
 -- when checking if can compose, need to match up individual elements, not whole list
 -- ex. If each component is operating at one token per 10 clocks, sequence of 4
--- parts will take 40 clocks, but should be able to add another component 
+-- parts will take 40 clocks, but should be able to add another component
 -- operating at one token per 10 clocks to get a sequence of 5 parts at 50 clocks
-(|.|) op0@(ComposeSeq ops0) op1@(ComposeSeq ops1) | canComposeSeq op1 op0 = 
+(|.|) op0 op1 | composeSeqFailure op1 op0 /= Nothing =
+  case composeSeqFailure op1 op0 of
+    Just failure -> failure
+    Nothing -> error "Aetherling internal error: missing ComposeFailure."
+(|.|) op0@(ComposeSeq ops0) op1@(ComposeSeq ops1) =
   ComposeSeq $ ops1 ++ ops0
-(|.|) op0@(ComposeSeq ops0) op1 | canComposeSeq op1 op0 =
+(|.|) op0@(ComposeSeq ops0) op1 =
   ComposeSeq $ [op1] ++ ops0
-(|.|) op0 op1@(ComposeSeq ops1) | canComposeSeq op1 op0 =
+(|.|) op0 op1@(ComposeSeq ops1) =
   ComposeSeq $ ops1 ++ [op0]
-(|.|) op0 op1 | canComposeSeq op1 op0 =
+(|.|) op0 op1 =
   ComposeSeq $ [op1] ++ [op0]
-(|.|) op0 op1 = Failure $ ComposeFailure (SeqPortMismatch (outThroughput op1) 
-  (inThroughput op0)) (op1, op0)
 
--- | This is in same spirit as Monad's >>=, kinda abusing notation
--- It's |.| in reverse so that can create pipelines in right order
+-- | This is |.| but in reverse so can create pipelines in logical order. It's
+-- in same spirit as Monad's >>=, kinda abusing notation
 (|>>=|) :: Op -> Op -> Op
 (|>>=|) op0 op1 = op1 |.| op0
 
--- | only join two sequential nodes if same numbers of ports, toke types match,
--- and steady state throughputs match
-canComposeSeq :: Op -> Op -> Bool
-canComposeSeq op0 op1 | (length . outPorts) op0 == (length . inPorts) op1 =
-  foldl (&&) True $ map portPairMatches (zip (outPorts op0) (inPorts op1))
-  where
-    portPairMatches (portOp0, portOp1) = portThroughput op0 portOp0 == 
-      portThroughput op1 portOp1
-canComposeSeq _ _ = False
+-- | Only join two sequential synchronous nodes if same numbers of
+-- ports, token types match, and steady state throughputs match. For
+-- ready-valid joins, skip the throughput matching check. Return
+-- Nothing if the nodes match, and a Failure if they don't, with an
+-- appropriate reason.
+composeSeqFailure :: Op -> Op -> Maybe Op
+composeSeqFailure op0 op1 =
+  case (outPortsReadyValid op0, inPortsReadyValid op1) of
+    -- Matching 2 ready-valid ops.
+    (Just True, Just True) ->
+      if length (outPorts op0) /= length (inPorts op1) then
+        Just $ Failure $ ComposeFailure PortCountMismatch (op1, op0)
+      else
+        composeSeqTokenTypeFailure op0 op1
+
+    -- Matching 2 synchronous ops.
+    (Just False, Just False) ->
+      if length (outPorts op0) /= length (inPorts op1) then
+        Just $ Failure $ ComposeFailure PortCountMismatch (op1, op0)
+      else if composeSeqTokenTypeFailure op0 op1 /= Nothing then
+        composeSeqTokenTypeFailure op0 op1
+      else
+        if all portPairMatches (zip (outPorts op0) (inPorts op1))
+        then
+          Nothing
+        else
+          Just $ Failure $ ComposeFailure
+            (SeqPortMismatch (outThroughput op1) (inThroughput op0)) (op1, op0)
+      where
+        portPairMatches (portOp0, portOp1) =
+          portThroughput op0 portOp0 == portThroughput op1 portOp1
+
+    -- Trivial case: matching 2 ops with no out/in ports.
+    (Nothing, Nothing) -> Nothing
+
+    -- Mismatching an op that has no out/in ports with one that does.
+    (Nothing, _) -> Just $ Failure $ ComposeFailure PortCountMismatch (op1, op0)
+    (_, Nothing) -> Just $ Failure $ ComposeFailure PortCountMismatch (op1, op0)
+
+    -- Mismatching ready-valid with synchronous ops.
+    (Just True, Just False) ->
+      Just $ Failure $ ComposeFailure ReadyValidMismatch (op1, op0)
+    (Just False, Just True) ->
+      Just $ Failure $ ComposeFailure ReadyValidMismatch (op1, op0)
+
+-- Helper function for above.
+-- Check that the token types of the two ops' out/in ports match,
+-- return a failure if they don't. Does no other checks.
+composeSeqTokenTypeFailure :: Op -> Op -> Maybe Op
+composeSeqTokenTypeFailure op0 op1 =
+  let
+    pairMismatch (portOp0, portOp1) = pTType portOp0 /= pTType portOp1
+    mismatches = filter pairMismatch (zip (outPorts op0) (inPorts op1))
+  in
+    if null mismatches then Nothing
+    else Just $ Failure $ ComposeFailure
+      (TokenTypeMismatch (fst (head mismatches)) (snd (head mismatches)) )
+       (op1, op0)
 
 -- | This is for making ComposePar
 (|&|) :: Op -> Op -> Op
+(|&|) op0 op1 | composeParFailure op0 op1 /= Nothing =
+  case composeParFailure op0 op1 of
+    Nothing -> error "Aetherling internal error: Missing ComposeFailure."
+    Just failure -> failure
 (|&|) (ComposePar ops0) (ComposePar ops1) = ComposePar $ ops0 ++ ops1
 (|&|) (ComposePar ops0) op1 = ComposePar $ ops0 ++ [op1]
 (|&|) op0 (ComposePar ops1) = ComposePar $ [op0] ++ ops1
 (|&|) op0 op1 = ComposePar $ [op0] ++ [op1]
+
+-- Check for a ReadyValidMismatch between the two parallel nodes.  Do
+-- this separately for input and for output. Return Nothing if no
+-- mismatch found.
+composeParFailure :: Op -> Op -> Maybe Op
+composeParFailure op0 op1 =
+  case (outPortsReadyValid op0, inPortsReadyValid op1) of
+    (Just True, Just False) ->
+      Just $ Failure $ ComposeFailure ReadyValidMismatch (op1, op0)
+    (Just False, Just True) ->
+      Just $ Failure $ ComposeFailure ReadyValidMismatch (op1, op0)
+    (_, _) -> Nothing

--- a/src/Core/Aetherling/Operations/Properties.hs
+++ b/src/Core/Aetherling/Operations/Properties.hs
@@ -58,6 +58,7 @@ isComb (Register _ _ _) = False
 
 isComb (ComposePar ops) = length (filter isComb ops) > 0
 isComb (ComposeSeq ops) = length (filter isComb ops) > 0
+isComb (ReadyValid op) = isComb op -- Should it actually be always False?
 isComb (Failure _) = True
 
 hasInternalState :: Op -> Bool
@@ -109,4 +110,5 @@ hasInternalState (Register _ _ _) = True
 
 hasInternalState (ComposePar ops) = length (filter hasInternalState ops) > 0
 hasInternalState (ComposeSeq ops) = length (filter hasInternalState ops) > 0
+hasInternalState (ReadyValid op) = hasInternalState op
 hasInternalState (Failure _) = True

--- a/src/Core/Aetherling/Operations/ReadyValid.hs
+++ b/src/Core/Aetherling/Operations/ReadyValid.hs
@@ -1,0 +1,45 @@
+module Aetherling.Operations.ReadyValid (
+  portsReadyValid,
+  inPortsReadyValid,
+  outPortsReadyValid
+) where
+import Aetherling.Operations.AST
+import Aetherling.Operations.Types
+import Aetherling.Analysis.PortsAndThroughput
+
+-- | Inspect ports to determine if the op is ready valid.  Due to the
+-- restriction against using ComposePar on a mix of ready-valid and
+-- synchronous ops, we should either have all ports ready-valid or no
+-- ports ready-valid. Nothing if we detect an illegal mix.
+portsReadyValid :: [PortType] -> Maybe Bool
+portsReadyValid [] =
+  error "Aetherling internal error: empty port list in portsReadyValid."
+portsReadyValid ports | all (pReadyValid) ports = Just True
+portsReadyValid ports | all (not . pReadyValid) ports = Just False
+portsReadyValid _ = Nothing
+
+-- | Inspect the op's in ports to determine if its inputs are ready-valid.
+-- Return Nothing if there are no ports to inspect.
+inPortsReadyValid :: Op -> Maybe Bool
+inPortsReadyValid op =
+  if null $ inPorts op then Nothing
+  else let
+    result = portsReadyValid $ inPorts op
+  in
+    case result of
+      Nothing -> error (show op ++
+                 " has illegal mix of ready-valid and synchronous inputs.")
+      Just b -> Just b
+
+-- | Inspect the op's out ports to determine if its inputs are ready-valid.
+-- Return Nothing if there are no ports to inspect.
+outPortsReadyValid :: Op -> Maybe Bool
+outPortsReadyValid op =
+  if null $ outPorts op then Nothing
+  else let
+    result = portsReadyValid $ outPorts op
+  in
+    case result of
+      Nothing -> error (show op ++
+                 " has illegal mix of ready-valid and synchronous inputs.")
+      Just b -> Just b

--- a/src/Core/Aetherling/Operations/Types.hs
+++ b/src/Core/Aetherling/Operations/Types.hs
@@ -93,23 +93,23 @@ valueTypeTail _ = error "valueTypeTail of non-array non-unit ValueType"
 -- if we want to match the throughputs of 2 ready-valid ops for
 -- performance (not correctness) reasons.
 data PortType = T_Port {pName :: [Char], pSeqLen :: Int,
-  pTType :: TokenType, pCTime :: Int} deriving (Show)
+  pTType :: TokenType, pCTime :: Int, pReadyValid :: Bool} deriving (Show)
 
 instance Eq PortType where
   -- ignore names for equality, just check that all same
-  (==) (T_Port _ len0 tType0 pct0) (T_Port _ len1 tType1 pct1) = 
-    len0 == len1 && tType0 == tType1 && pct0 == pct1
+  (==) (T_Port _ len0 tType0 pct0 rv0) (T_Port _ len1 tType1 pct1 rv1) = 
+    len0 == len1 && tType0 == tType1 && pct0 == pct1 && rv0 == rv1
   (/=) pt0 pt1 = not $ pt0 == pt1
 
 -- lift the types of ports to handle arrays
 liftPortsTypes :: Int -> [PortType] -> [PortType]
 liftPortsTypes n ports = map wrapInArray ports
-  where wrapInArray (T_Port name sLen t pct) = T_Port name sLen (T_Array n t) pct
+  where wrapInArray (T_Port name sLen t pct rv) = T_Port name sLen (T_Array n t) pct rv
 
 renamePorts :: String -> [PortType] -> [PortType]
 renamePorts templateName ports = snd $ foldl renameAndIncrementCounter (0, []) ports
-  where renameAndIncrementCounter (curCounter, processedPorts) (T_Port _ sLen tType pct) =
-          (curCounter + 1, processedPorts ++ [T_Port (templateName ++ show curCounter) sLen tType pct])
+  where renameAndIncrementCounter (curCounter, processedPorts) (T_Port _ sLen tType pct rv) =
+          (curCounter + 1, processedPorts ++ [T_Port (templateName ++ show curCounter) sLen tType pct rv])
 
 data PortThroughput = PortThroughput {throughputType :: TokenType, 
   throughputTypePerClock :: Ratio Int} deriving (Show, Eq)

--- a/src/Core/Aetherling/Passes/MapOps.hs
+++ b/src/Core/Aetherling/Passes/MapOps.hs
@@ -67,6 +67,7 @@ mapChildLeaf2 mapf _ (ReduceOp num par op) = ReduceOp num par (mapf op)
 mapChildLeaf2 _ leaf op@(NoOp _) = leaf op
 mapChildLeaf2 mapf _ (LogicalUtil ratio op) = LogicalUtil ratio (mapf op)
 mapChildLeaf2 _ leaf op@(Register _ _ _) = leaf op
+mapChildLeaf2 mapf _ (ReadyValid op) = ReadyValid (mapf op)
 mapChildLeaf2 mapf _ (ComposePar []) = ComposePar []
 mapChildLeaf2 mapf _ (ComposePar ops) =
   foldl1 (|&|) (map mapf ops)

--- a/src/Core/Aetherling/Simulator/Simulator.hs
+++ b/src/Core/Aetherling/Simulator/Simulator.hs
@@ -206,6 +206,8 @@ simhl op@(ComposeSeq _) inStrs state =
     simhlSeq simhl op inStrs state
 simhl op@(ComposePar _) inStrs state =
     simhlPar simhl op inStrs state
+simhl (ReadyValid op) inStrs state =
+    simhl op inStrs state
 simhl (Failure _) _ _ =
     error "Aetherling internal error: Failure in simulation."
 
@@ -308,6 +310,8 @@ simhlPre opStack@(ComposePar _:_) inStrLens inState =
     simhlPrePar simhlPre opStack inStrLens inState
 simhlPre opStack@(ComposeSeq _:_) inStrLens inState =
     simhlPreSeq simhlPre opStack inStrLens inState
+simhlPre opStack@(ReadyValid op:_) inStrLens inState =
+    simhlPre (op:opStack) inStrLens inState
 simhlPre opStack@(Failure _:_) inStrLens inState =
     error("Failure cannot be simulated at\n"
        ++ (simhlFormatOpStack opStack))

--- a/test/TestCompose.hs
+++ b/test/TestCompose.hs
@@ -104,34 +104,34 @@ composeTest9 =
 -- Make sure ComposeSeq detects port count mismatches.
 composeTest10 =
   testComposeFailure
-    "Illegal ComposeSeq of ops with different number of ports." $
+    "Illegal ComposeSeq of ops with different number of ports" $
     And |>>=| Or
 
 
 -- Make sure ComposeSeq rejects mix of ready-valid and synchronous.
 composeTest11 =
   testComposeFailure
-    "Illegal ComposeSeq of non-ready-valid and ready-valid ops." $
+    "Illegal ComposeSeq of non-ready-valid and ready-valid ops" $
     readyValid XOr |>>=| readyValid Not |>>=| MemWrite T_Bit
 
 
 -- Make sure ComposeSeq ready-valid mixing test sees inside ComposePar.
 composeTest12 =
   testComposeFailure
-    "Illegal ComposeSeq of non-ready-valid and ready-valid ComposePars." $
+    "Illegal ComposeSeq of non-ready-valid and ready-valid ComposePars" $
     (readyValid (MemRead T_Int) |&| readyValid (MemRead T_Int))
     |>>=| Mul
 
 composeTest13 =
   testComposeFailure
-    "Illegal ComposeSeq of non-ready-valid and ready-valid, reversed." $
+    "Illegal ComposeSeq of non-ready-valid and ready-valid, reversed" $
     (MemRead T_Int |&| MemRead T_Int) |>>=| readyValid Mul
 
 
 -- Make sure ComposePar rejects mix of ready-valid and non-ready-valid.
 composeTest14 =
   testComposeFailure
-    "Illegal ComposePar of ready-valid and non-ready-valid." $
+    "Illegal ComposePar of ready-valid and non-ready-valid" $
     readyValid (MemRead T_Int) |&| mapOp 4 XOrInt
 
 
@@ -139,14 +139,14 @@ composeTest14 =
 -- illegal ready-valid mix.
 composeTest15 =
   testComposeFailure
-    "Illegal ComposePar of mismatched ready-valid in ComposeSeq." $
+    "Illegal ComposePar of mismatched ready-valid in ComposeSeq" $
     (readyValid (MemRead T_Int) |>>=| readyValid NotInt) |&|  Or
 
 
 -- Make sure ComposeSeq of non-ready-valid detects throughput mismatches.
 composeTest16 =
   testComposeFailure
-    "Illegal throughput mismatch in ComposeSeq." $
+    "Illegal throughput mismatch in ComposeSeq" $
     reduceOp 4 2 Mul |>>=| MemWrite T_Int
 
 

--- a/test/TestCompose.hs
+++ b/test/TestCompose.hs
@@ -1,0 +1,172 @@
+-- Tests for compose functions and stuff that work on compose ops.
+module TestCompose where
+import Aetherling.Operations.AST
+import Aetherling.Operations.Ops
+import Aetherling.Operations.Compose
+import Aetherling.Operations.Types
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- Create a test case that expects a failure.
+-- Map all failures to Nothing, and non-failures to Just Op.
+-- This way, if we fail to get the expected failure, we can see
+-- the op that should have failed in the Just data field.
+--
+-- Should we also check that the failure has a reasonable reason field?
+testComposeFailure :: String -> Op -> TestTree
+testComposeFailure description op =
+  let
+    maybe = case op of
+      (Failure _) -> Nothing
+      op' -> Just op'
+  in
+    testCase description (maybe @?= Nothing)
+
+
+-- Make sure that normal ComposeSeq is working.
+composeTest1 =
+  testCase
+    "Normal ComposeSeq" $
+    (mapOp 2 NotInt |>>=| reduceOp 4 2 Add |>>=| underutil 2 (MemWrite T_Int))
+    @?=
+    ComposeSeq [mapOp 2 NotInt, reduceOp 4 2 Add, underutil 2 (MemWrite T_Int)]
+
+
+-- Make sure that ComposeSeq of ReadyValid is working.
+composeTest2 =
+  testCase
+    "ComposeSeq of ready-valid" $
+    (readyValid XOr |>>=| readyValid Not |>>=| readyValid (MemWrite T_Bit))
+    @?=
+    ComposeSeq [readyValid XOr, readyValid Not, readyValid (MemWrite T_Bit)]
+
+
+-- Make sure ComposeSeq of ReadyValid ignores throughput mismatch.
+composeTest3 =
+  testCase
+    "ComposeSeq of ready-valid should ignore throughput mismatch" $
+    (readyValid (reduceOp 4 2 Add) |>>=| readyValid (MemWrite T_Int))
+    @?=
+    ComposeSeq [readyValid (reduceOp 4 2 Add), readyValid (MemWrite T_Int)]
+
+
+-- Make sure normal ComposePar is working.
+composeTest4 =
+  testCase
+    "Normal ComposePar" $
+    (And |&| AndInt |&| MemRead (tBits [16]) |&| genConstant T_Int [3])
+    @?=
+    ComposePar [And, AndInt, MemRead (tBits [16]), genConstant T_Int [3]]
+
+
+-- Make sure ComposePar of ready valid is working.
+composeTest5 =
+  testCase
+    "ComposePar of ready-valid" $
+    (readyValid (MemRead T_Int) |&| readyValid Mul |&| readyValid Div)
+    @?=
+    ComposePar [readyValid (MemRead T_Int), readyValid Mul, readyValid Div]
+
+
+-- Make sure ComposeSeq can "see" that MapOp contains ready-valid ops.
+composeTest6 =
+  testCase
+    "ComposeSeq of ComposePar of ready-valid" $
+    ((readyValid (MemRead T_Bit) |&| readyValid (MemRead T_Bit))
+         |>>=| readyValid And)
+    @?=
+    ComposeSeq [
+      ComposePar [readyValid (MemRead T_Bit), readyValid (MemRead T_Bit)],
+      readyValid And ]
+
+
+-- Make sure ComposeSeq rejects type mismatches.
+composeTest7 =
+  testComposeFailure
+    "Illegal ComposeSeq of int and bit operators" $
+    Add |>>=| Not
+
+
+-- Make sure ComposeSeq rejects array type mismatches.
+composeTest8 =
+  testComposeFailure
+    "Illegal ComposeSeq of incompatible bit arrays" $
+    arrayReshape [T_Bit] [tBits [1]] |>>=| mapOp 2 Not
+
+
+-- Make sure ComposeSeq can see type mismatch in long chain.
+composeTest9 =
+  testComposeFailure
+    "ComposeSeq chain with type mismatch" $
+    And |>>=| duplicateOutputs 2 Not |>>=| XOr |>>=| NotInt |>>=| MemWrite T_Int
+
+
+-- Make sure ComposeSeq detects port count mismatches.
+composeTest10 =
+  testComposeFailure
+    "Illegal ComposeSeq of ops with different number of ports." $
+    And |>>=| Or
+
+
+-- Make sure ComposeSeq rejects mix of ready-valid and synchronous.
+composeTest11 =
+  testComposeFailure
+    "Illegal ComposeSeq of non-ready-valid and ready-valid ops." $
+    readyValid XOr |>>=| readyValid Not |>>=| MemWrite T_Bit
+
+
+-- Make sure ComposeSeq ready-valid mixing test sees inside ComposePar.
+composeTest12 =
+  testComposeFailure
+    "Illegal ComposeSeq of non-ready-valid and ready-valid ComposePars." $
+    (readyValid (MemRead T_Int) |&| readyValid (MemRead T_Int))
+    |>>=| Mul
+
+composeTest13 =
+  testComposeFailure
+    "Illegal ComposeSeq of non-ready-valid and ready-valid, reversed." $
+    (MemRead T_Int |&| MemRead T_Int) |>>=| readyValid Mul
+
+
+-- Make sure ComposePar rejects mix of ready-valid and non-ready-valid.
+composeTest14 =
+  testComposeFailure
+    "Illegal ComposePar of ready-valid and non-ready-valid." $
+    readyValid (MemRead T_Int) |&| mapOp 4 XOrInt
+
+
+-- Make sure ComposePar can see inside ComposeSeq when rejecting
+-- illegal ready-valid mix.
+composeTest15 =
+  testComposeFailure
+    "Illegal ComposePar of mismatched ready-valid in ComposeSeq." $
+    (readyValid (MemRead T_Int) |>>=| readyValid NotInt) |&|  Or
+
+
+-- Make sure ComposeSeq of non-ready-valid detects throughput mismatches.
+composeTest16 =
+  testComposeFailure
+    "Illegal throughput mismatch in ComposeSeq." $
+    reduceOp 4 2 Mul |>>=| MemWrite T_Int
+
+
+composeTests = testGroup "Compose op tests" $
+  [
+    composeTest1,
+    composeTest2,
+    composeTest3,
+    composeTest4,
+    composeTest5,
+    composeTest6,
+    composeTest7,
+    composeTest8,
+    composeTest9,
+    composeTest10,
+    composeTest11,
+    composeTest12,
+    composeTest13,
+    composeTest14,
+    composeTest15,
+    composeTest16
+  ]
+

--- a/test/TestMain.hs
+++ b/test/TestMain.hs
@@ -6,9 +6,10 @@ import Aetherling.SimpleExamples
 import TestSimulator
 import TestThroughputPasses
 import TestSimpleExamples
+import TestCompose
 
 main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Example Tests" [simpleExamplesTests, simulatorTests, throughputTests]
+tests = testGroup "Example Tests" [simpleExamplesTests, simulatorTests, throughputTests, composeTests]

--- a/test/TestSimpleExamples.hs
+++ b/test/TestSimpleExamples.hs
@@ -19,6 +19,7 @@ simpleExamplesTests = testGroup "Verifying Simple Examples Aren't Failures"
     testCase "2 pixels per clock, 3 pixel stencil linebuffer" $ isSuccess lb23 @?= True,
     testCase "underutilized to only every other clock - 1 pixel per clock, 3 pixel stencil linebuffer" $ isSuccess lb13Underutil @?= True,
     testCase "back-to-back 1 pixel per clock, 3 pixel stencil linebuffers" $ isSuccess lbChain @?= True,
+    testCase "back-to-back 1 pixel per clock, 3 pixel stencil linebuffers with ready-valid" $ isSuccess lbChainReadyValid @?= True,
     testCase "basic memory reading one int per clock" $ isSuccess memReadInt @?= True,
     testCase "basic memory writing one int per clock" $ isSuccess memWriteInt @?= True,
     testCase "A reshape converting int[2]{1} to int{2} every two clocks" $ isSuccess spaceAndTimeReshape @?= True,

--- a/test/TestSimulator.hs
+++ b/test/TestSimulator.hs
@@ -282,11 +282,11 @@ simhlCase5 = SimhlTestCase
   199
   []
 
--- Same thing, but take 15 inputs sequentially.
+-- Same thing, but take 15 inputs sequentially, and test readyValid here.
 simhlMul7Max15TimeOp =
-  (simhlBox T_Int |&| underutil 15 (Constant_Int [7])) |>>=|
-  (ReduceOp 15 1 Max |&| underutil 15 (simhlUnbox T_Int)) |>>=|
-  (underutil 15 Mul)
+  readyValid (simhlBox T_Int |&| underutil 15 (Constant_Int [7])) |>>=|
+  readyValid (ReduceOp 15 1 Max |&| underutil 15 (simhlUnbox T_Int)) |>>=|
+  readyValid (underutil 15 Mul)
 simhlMul7Max15TimeImpl :: [[ValueType]] -> [[ValueType]]
                        -> ( [[ValueType]], [[ValueType]] )
 simhlMul7Max15TimeImpl portInputs _ =
@@ -298,8 +298,8 @@ simhlMul7Max15TimeImpl portInputs _ =
   in
     ([doMax $ head portInputs], [])
 simhlCase6 = SimhlTestCase
-  "Similar to the other maximum times 7, but input is sequential. \
-        \(Tests ReduceOp, Max)"
+  "Similar to the other maximum times 7, but input is sequential and using \
+        \ready-valid timing. (Tests ReduceOp, Max, ReadyValid)"
   simhlMul7Max15TimeOp
   simhlMul7Max15TimeImpl
   150


### PR DESCRIPTION
Adds ReadyValid op (wraps child op in ready-valid interface) and readyValid helper function.
Adds ready-valid Bool in PortType.
Modify ComposeSeq/ComposePar to handle ready-valid ops correctly.
Adds Compose tests.
