### PR TITLE
Low Priority: Change LineBufferManifesto outports to 3D instead of 4D.

### DIFF
--- a/src/Apps/Aetherling/Convolution.hs
+++ b/src/Apps/Aetherling/Convolution.hs
@@ -10,7 +10,7 @@ import Aetherling.Operations.Types
 -- 2^shift), and image size as (height, width). Since the new line
 -- buffer emits some windows with garbage pixels on the edges, the
 -- rule for us is that we output garbage on the upper and left
--- margins, with height/width equal to 1 less than the window
+-- margins, with height/width equal to 1 less than the kernel
 -- height/width.
 --
 -- Input and output of the pipeline are both Int streams.
@@ -29,28 +29,26 @@ appsMakeConvolution kernelRows shift (iY, iX) =
 
     -- The Aetherling type of the convolution matrix and window of
     -- pixels to multiply with.
-    array2D = T_Array kernelHeight (T_Array kernelWidth T_Int)
+    tStencil = tInts[kernelHeight, kernelWidth]
     
     -- Create a constant generator making the flipped convolution matrix
     -- as a 2D Aetherling array of Ints.
-    rowGenerators = map (Constant_Int . reverse) (reverse kernelRows)
-    kernel = (foldl1 (|&|) rowGenerators)
-      |>>=| ArrayReshape (replicate kernelHeight (T_Array kernelWidth T_Int))
-                         [array2D]
+    flippedMatrixFlat = foldr1 (++) $ reverse $ map reverse kernelRows
+    genKernelOp = genConstant tStencil flippedMatrixFlat
 
     -- Create windows of the input image the same size as the kernel
-    windows = ArrayReshape [T_Int] [T_Array 1 $ T_Array 1 T_Int]
-        |>>=| manifestoLineBuffer (1,1) (kernelHeight, kernelWidth) (iY, iX)
-                                  (1,1) (-kernelHeight+1, -kernelWidth+1) T_Int
-        |>>=| ArrayReshape [T_Array 1 $ T_Array 1 array2D] [array2D]
+    windowsOp = arrayReshape [T_Int] [tInts[1,1]]
+          |>>=| manifestoLineBuffer (1,1) (kernelHeight, kernelWidth) (iY, iX)
+                                    (1,1) (-kernelHeight+1, -kernelWidth+1) T_Int
+          |>>=| arrayReshape [T_Array 1 tStencil] [tStencil]
   in
     -- Now we just have to apply the kernel in one fell swoop.
     -- Elementwise multiply the windows with the kernel, flatten the
     -- products, add them all, and divide by the divisor.
-    (windows |&| kernel)
-    |>>=| mulI array2D
-    |>>=| ArrayReshape [array2D] [T_Array kernelSize T_Int]
-    |>>=| ReduceOp kernelSize kernelSize Add
+    (windowsOp |&| genKernelOp)
+    |>>=| mulInts tStencil
+    |>>=| arrayReshape [tStencil] [tInts[kernelSize]]
+    |>>=| reduceOp kernelSize kernelSize Add
     |>>=| Ashr shift
 
 -- Gaussian Blur pipeline (7 x 7 stencil for given (height, width)

--- a/src/Apps/Aetherling/MipMap.hs
+++ b/src/Apps/Aetherling/MipMap.hs
@@ -5,11 +5,17 @@ import Aetherling.Operations.AST
 import Aetherling.Operations.Ops
 import Aetherling.Operations.Compose
 import Aetherling.Operations.Types
+import Aetherling.Analysis.PortsAndThroughput
+import Data.Ratio
 
 -- Naive mipmap generation example (for power-of-two square
 -- textures). Each level is composed of pixels that are made by
 -- averaging a square of 4 pixels from the previous level. Operates on
 -- specified token type t.
+--
+-- tPixel is the token type representing pixels.
+--
+-- Original image size is (2^dimLog2, 2^dimLog2)
 --
 -- Input port type is array of t. If speedLog2 is >= 1, then the
 -- array size is 1 << speedLog2; otherwise, the array is size 1,
@@ -17,82 +23,100 @@ import Aetherling.Operations.Types
 -- written to memory at a speed 4x slower than the previous level, as
 -- a possibly underutiled array write as earlier.
 --
+-- speedLog2 cannot exceed dimLog2 (I don't support multiple rows of input
+-- per colck cycle).
+--
 -- The MemWrites are numbered from highest to lowest resolution; the
--- first one is the input image downsampled by 4 and the last just
+-- 0th one is the input image downsampled by 4 and the last just
 -- writes out a single pixel.
 appsMipMap :: TokenType -> Int -> Int -> Op
-appsMipMap t dimLog2 speedLog2 =
-  let
-    ((1, width), avgUnderutil) = getPxPerClkUnderutil dimLog2 speedLog2
-  in
-    avgUnderutil (
-      ArrayReshape [T_Array width t] [T_Array 1 (T_Array width t)]
-     ) |>>=| mipMapBoxed t dimLog2 speedLog2
+appsMipMap tPixel dimLog2 speedLog2
+  | dimLog2 <= 0 =
+    error "Need dimLog2 positive (at least 2x2 image needed)."
+  | dimLog2 < speedLog2 =
+    error "Sorry, MipMap op speedLog2 cannot exceed dimLog2 \n\
+          \(don't support multiple rows per clk)."
+  | otherwise = 
+    -- Just have to reshape from user's 1D input to 2D line buffer input,
+    -- then glue together all the mip map level generators.
+    let
+      levels = [mipMapLevel tPixel (dimLog2-lvl) (speedLog2-2*lvl)
+               | lvl <- [0..dimLog2-1]]
+      reshapeOp = arrayReshape [T_Array (2^speedLog2) tPixel]
+                               [T_Array 1 $ T_Array (2^speedLog2) tPixel]
+    in
+      foldl (|>>=|) reshapeOp levels
 
--- Boxed because there's an extra annoying T_Array 1 wrapping input.
-mipMapBoxed :: TokenType -> Int -> Int -> Op
-mipMapBoxed t dimLog2 speedLog2
-  | speedLog2 > dimLog2 = error "speedLog2 cannot exceed dimLog2"
-  | dimLog2 < 0 = error "dimLog2 must be non-negative"
-  | dimLog2 == 0 =
-    underutil (2^(-speedLog2)) $
-      ArrayReshape [T_Array 1 (T_Array 1 t)] [T_Array 1 t]
-      |>>=| MemWrite (T_Array 1 t)
-  | otherwise = mipMapLevel t dimLog2 speedLog2
-          |>>=| mipMapBoxed t (dimLog2-1) (speedLog2-2)
 
--- Generate one level of the MipMap pyramid. Writes results to both
--- an output port and to a MemWrite.
--- * t = TokenType
--- * dimLog2 = log2 of input image dimensions. Output image has size
---           (1 << (dimLog2-1), 1 << (dimLog2-1)).
+-- Generate one level of the MipMap pyramid. (Downsamples & averages
+-- image by factor of 2 in y and x). Writes results to both an output
+-- port and to a MemWrite.
+--
+-- * tPixel = TokenType of pixel
+-- * dimLog2 = log2 of input image dimensions. Downsampled output image
+--             has size (1 << (dimLog2-1), 1 << (dimLog2-1)).
 -- * speedLog2 = log2 of input pixels per clock.
 -- SpeedLog2 can be positive or negative, but cannot exceed the dimLog2.
 -- The output speed will be 4 times slower than input speed
 -- (i.e. the next level should have speedLog2 2 less than our speedLog2).
+--
+-- Input and output are both 2D-arrays of int. Width of input array is
+-- max(1, 2^speedLog2); width of output array is max(1, 2^speedLog2 / 4),
+-- height of both is 1 (no support for multiple rows / clk).
 mipMapLevel :: TokenType -> Int -> Int -> Op
-mipMapLevel t dimLog2 speedLog2 =
+mipMapLevel tPixel dimLog2 speedLog2 =
   let
-    (pxPerClk, applyUnderutil) = getPxPerClkUnderutil dimLog2 speedLog2
+    makePresetSpeedLB = presetSpeedLineBufferFactory speedLog2
 
     -- Line buffer for splitting input into 2x2 chunks. Note stride
     -- (2,2) matches window (2,2), so these chunks tile the image
     -- perfectly.
-    lb = applyUnderutil $
-      manifestoLineBuffer pxPerClk (2,2) (2^dimLog2, 2^dimLog2) (2,2) (0,0) t
+    lineBufferOp =
+      makePresetSpeedLB (2,2) (2^dimLog2, 2^dimLog2) (2,2) (0,0) tPixel
 
-    -- Module that averages 2x2 pixels to 1 int.
-    average2x2 = ArrayReshape [T_Array 2 (T_Array 2 t)] [T_Array 4 t]
-           |>>=| ReduceOp 4 4 (addI t)
-           |>>=| ashr 2 t -- Better rounding would be nice.
+    -- Module that averages 2x2 pixels to 1 int. Window token type is tWindow.
+    tWindow = T_Array 2 (T_Array 2 tPixel)
+    average2x2Op = arrayReshape [tWindow] [T_Array 4 tPixel]
+             |>>=| reduceOp 4 4 (addInts tPixel)
+             |>>=| ashr 2 tPixel -- Better rounding would be nice.
 
-    -- Downstream of the line buffer, we're slowed by 4x due to the
-    -- strides.  We have to map/underutil the 4x4 averager and the
-    -- MemWrite to match.  (We "map" the MemWrite manually by
-    -- adjusting its TokenType array size so there's still only one
-    -- MemWrite output). Duplicate to get both port and mem output.
-    ((1, width), avgUnderutil) = getPxPerClkUnderutil dimLog2 (speedLog2 - 2)
-    mappedAverage = MapOp 1 (MapOp width average2x2)
+    -- Now we have to hook up each 2x2 window output to an averaging
+    -- device.  This device needs to be mapped (to match the line
+    -- buffer's output parallelism) and maybe underutilized (to match
+    -- the line buffer's speed).
 
-    memToken = T_Array width t
-    shapedMemWrite = ArrayReshape [T_Array 1 memToken] [memToken]
-      |>>=| MemWrite memToken
+    -- Inspect line buffer to get its parallelism and utilization.
+    lbOutPort = head $ outPorts lineBufferOp
+    T_Array parallelism _ = pTType lbOutPort
+    outputUtilRatio = (pSeqLen lbOutPort) % cps lineBufferOp
 
-    downstream = avgUnderutil $
-      DuplicateOutputs 2 mappedAverage
-      |>>=| (NoOp [T_Array 1 memToken] |&| shapedMemWrite)
+    -- Mapped (but not yet underutilized) 2x2 averaging devices.
+    mappedAverageOp = mapOp parallelism average2x2Op
+
+    -- Everything downstream from the line buffer, at correct speed.
+    -- Write averaged outputs to 2D output port (thru arrayReshape)
+    -- and to 1D array memory.
+    tFlatOutput = T_Array parallelism tPixel
+    downstreamOp = scaleUtil outputUtilRatio $
+      duplicateOutputs 2 mappedAverageOp
+      |>>=| (arrayReshape [tFlatOutput] [T_Array 1 tFlatOutput]
+             |&| MemWrite tFlatOutput)
   in
-    lb |>>=| downstream
+    -- Last thing is, need to reshape from 1D array input to 2D line
+    -- buffer input.
+    lineBufferOp |>>=| downstreamOp
 
--- Depending on speedLog2 we either have to widen pxPerClk or underutil.
--- Function returning a suitable pxPerClk parameter and a function that
--- optionally wraps an op with an underutil.
-getPxPerClkUnderutil :: Int -> Int -> ((Int, Int), (Op -> Op))
-getPxPerClkUnderutil dimLog2 speedLog2 =
-  if speedLog2 > dimLog2 then
-    error "speedLog2 cannot exceed dimLog2 \
-          \(can't input more than 1 row in one clock)"
-  else if speedLog2 >= 0 then
-    ((1, 2^speedLog2), id)
-  else
-    ((1, 1), underutil (2^(-speedLog2)))
+-- Depending on speedLog2 (log2 of avg in pixels/clk), we either have
+-- to widen pxPerClk or underutil. This function returns a function
+-- that produces a line buffer, given all line buffer parameters
+-- EXCEPT pxPerClk. That parameter is set automatically to match the
+-- dictated speed.
+presetSpeedLineBufferFactory :: Int ->
+  ((Int,Int) -> (Int,Int) -> (Int,Int) -> (Int,Int) -> TokenType -> Op)
+presetSpeedLineBufferFactory speedLog2
+  | speedLog2 >= 0 =
+    manifestoLineBuffer (1, 2^speedLog2)
+  | otherwise =
+    \window image stride origin token ->
+      underutil (2^(-speedLog2)) $
+        manifestoLineBuffer (1,1) window image stride origin token

--- a/src/Core/Aetherling/LineBufferManifestoModule.hs
+++ b/src/Core/Aetherling/LineBufferManifestoModule.hs
@@ -127,7 +127,7 @@ manifestoOutPorts lb =
     windowCount = div imgArea strideArea
     seqLen = div windowCount parallelism
     windowToken = T_Array winY $ T_Array winX (lbToken lb)
-    arrayToken = T_Array 1 $ T_Array parallelism $ windowToken
+    arrayToken = T_Array parallelism $ windowToken
   in
     if yPerClk /= 1 then
       error "Expected pxPerClk to have height 1."
@@ -244,7 +244,7 @@ manifestoSimulate lb [inStr] =
     pack windows =
       let
         (theseWindows, laterWindows) = splitAt parallelism windows
-        thisOut = V_Array [ V_Array theseWindows ]
+        thisOut = V_Array theseWindows
         laterOut = pack laterWindows
       in
         thisOut:laterOut


### PR DESCRIPTION
Changes output interface of LineBufferManifesto from 4D to 3D to match native line buffer's magma type.